### PR TITLE
Web app online config

### DIFF
--- a/cordova-plugin-outline/outlinePlugin.js
+++ b/cordova-plugin-outline/outlinePlugin.js
@@ -38,6 +38,7 @@ function quitApplication() {
 }
 
 // This must be kept in sync with:
+//  - cordova-plugin-outline/android/java/org/outline/OutlinePlugin.java#ErrorCode
 //  - cordova-plugin-outline/apple/src/OutlineVpn.swift#ErrorCode
 //  - cordova-plugin-outline/apple/vpn/PacketTunnelProvider.h#NS_ENUM
 //  - www/model/errors.ts
@@ -54,7 +55,11 @@ const ERROR_CODE = {
   CONFIGURE_SYSTEM_PROXY_FAILURE: 9,
   NO_ADMIN_PERMISSIONS: 10,
   UNSUPPORTED_ROUTING_TABLE: 11,
-  SYSTEM_MISCONFIGURED: 12
+  SYSTEM_MISCONFIGURED: 12,
+  DNS_RESOLUTION_ERROR: 13,
+  TLS_CERTIFICATE_ERROR: 14,
+  HTTP_ERROR: 15,
+  UNSUPPORTED_SERVER_CONFIGURATION: 16
 };
 
 // This must be kept in sync with the TypeScript definition:

--- a/cordova-plugin-outline/outlinePlugin.js
+++ b/cordova-plugin-outline/outlinePlugin.js
@@ -37,8 +37,6 @@ function quitApplication() {
   exec(function() {}, function() {}, PLUGIN_NAME, 'quitApplication', []);
 }
 
-var globalId = 100;  // Internal, incremental ID.
-
 // This must be kept in sync with:
 //  - cordova-plugin-outline/apple/src/OutlineVpn.swift#ErrorCode
 //  - cordova-plugin-outline/apple/vpn/PacketTunnelProvider.h#NS_ENUM
@@ -65,22 +63,16 @@ function OutlinePluginError(errorCode) {
   this.errorCode = errorCode || ERROR_CODE.UNEXPECTED;
 }
 
+// This must be kept in sync with the TypeScript definition:
+//   www/app/tunnel.ts
 const TunnelStatus = {
   CONNECTED: 0,
   DISCONNECTED: 1,
   RECONNECTING: 2
 }
 
-function Tunnel(config, id) {
-  if (id) {
-    this.id_ = id.toString();
-  } else {
-    this.id_ = (globalId++).toString();
-  }
-
-  if (!config) {
-    throw new Error('Server configuration is required');
-  }
+function Tunnel(id, config) {
+  this.id = id;
   this.config = config;
 }
 
@@ -89,15 +81,25 @@ Tunnel.prototype._promiseExec = function(cmd, args) {
     const rejectWithError = function(errorCode) {
       reject(new OutlinePluginError(errorCode));
     };
-    exec(resolve, rejectWithError, PLUGIN_NAME, cmd, [this.id_].concat(args));
+    exec(resolve, rejectWithError, PLUGIN_NAME, cmd, [this.id].concat(args));
   }.bind(this));
 };
 
 Tunnel.prototype._exec = function(cmd, args, success, error) {
-  exec(success, error, PLUGIN_NAME, cmd, [this.id_].concat(args));
+  exec(success, error, PLUGIN_NAME, cmd, [this.id].concat(args));
+};
+
+Tunnel.prototype.fetchProxyConfig = function(configSource) {
+  if (!configSource) {
+    throw new OutlinePluginError(ERROR_CODE.ILLEGAL_SERVER_CONFIGURATION);
+  }
+  return this._promiseExec('fetchProxyConfig', [configSource]);
 };
 
 Tunnel.prototype.start = function() {
+  if (!this.config) {
+    throw new OutlinePluginError(ERROR_CODE.ILLEGAL_SERVER_CONFIGURATION);
+  }
   return this._promiseExec('start', [this.config]);
 };
 
@@ -110,12 +112,15 @@ Tunnel.prototype.isRunning = function() {
 };
 
 Tunnel.prototype.isReachable = function() {
+  if (!this.config) {
+    return new Promise.reject(new OutlinePluginError(ERROR_CODE.ILLEGAL_SERVER_CONFIGURATION));
+  }
   return this._promiseExec('isReachable', [this.config.host, this.config.port]);
 };
 
 Tunnel.prototype.onStatusChange = function(listener) {
   const onError = function(err) {
-    console.warn('Failed to execute disconnect listener', err);
+    console.warn('failed to execute status change listener', err);
   };
   this._exec('onStatusChange', [], listener, onError);
 };

--- a/src/types/ambient/outlinePlugin.d.ts
+++ b/src/types/ambient/outlinePlugin.d.ts
@@ -16,7 +16,10 @@
 
 declare type Tunnel = import('../../www/app/tunnel').Tunnel;
 declare type TunnelStatus = import('../../www/app/tunnel').TunnelStatus;
+declare type ProxyConfigResponse = import('../../www/app/tunnel').ProxyConfigResponse;
 declare type ShadowsocksConfig = import('../../www/model/shadowsocks').ShadowsocksConfig;
+declare type ShadowsocksConfigSource =
+    import('../../www/model/shadowsocks').ShadowsocksConfigSource;
 
 declare namespace cordova.plugins.outline {
   const log: {
@@ -34,13 +37,13 @@ declare namespace cordova.plugins.outline {
 
   // Implements the Tunnel interface with native functionality.
   class Tunnel implements Tunnel {
-    // Creates a new instance with `config`.
-    // A sequential ID will be generated if `id` is absent.
-    constructor(config: ShadowsocksConfig, id?: string);
+    constructor(id: string, config?: ShadowsocksConfig);
 
-    config: ShadowsocksConfig;
+    config?: ShadowsocksConfig;
 
     readonly id: string;
+
+    fetchProxyConfig(source: ShadowsocksConfigSource): Promise<ProxyConfigResponse>;
 
     start(): Promise<void>;
 

--- a/src/www/app/app.ts
+++ b/src/www/app/app.ts
@@ -177,6 +177,8 @@ export class App {
     } else {
       messageKey = 'error-unexpected';
     }
+    // TODO(alalama): messages, l10n for UnsupportedServerConfiguration, TlsCertificateError,
+    // DomainResolutionError, HttpError
 
     const message =
         messageParams ? this.localize(messageKey, ...messageParams) : this.localize(messageKey);
@@ -314,15 +316,22 @@ export class App {
   private confirmAddServer(accessKey: string, fromClipboard = false) {
     const addServerView = this.rootEl.$.addServerView;
     accessKey = unwrapInvite(accessKey);
-    if (fromClipboard && accessKey in this.ignoredAccessKeys) {
-      return console.debug('Ignoring access key');
-    } else if (fromClipboard && addServerView.isAddingServer()) {
-      return console.debug('Already adding a server');
+    if (!accessKey) {
+      return console.warn('Attempted to add an empty access key');
+    }
+    if (fromClipboard) {
+      if (accessKey in this.ignoredAccessKeys) {
+        return console.debug('Ignoring access key');
+      } else if (addServerView.isAddingServer()) {
+        return console.debug('Already adding a server');
+      } else if (!accessKey.startsWith('ss://')) {
+        return console.debug('Ignoring non ss: URL from clipboard');
+      }
     }
 
     let serverConfig: ServerConfig;
     // TODO(alalama): support ssconf://?
-    if (accessKey.startsWith('https://')) {
+    if (accessKey.startsWith('https://') && new URL(accessKey)) {
       serverConfig = {source: {url: accessKey}};
       // TODO(alalama): refine name, l10n
       serverConfig.name = 'Dynamic Server';

--- a/src/www/app/cordova_main.ts
+++ b/src/www/app/cordova_main.ts
@@ -71,8 +71,8 @@ class CordovaPlatform implements OutlinePlatform {
     return (serverId: string, config: ServerConfig, eventQueue: EventQueue) => {
       return new OutlineServer(
           serverId, config,
-          this.hasDeviceSupport() ? new cordova.plugins.outline.Tunnel(config, serverId) :
-                                    new FakeOutlineTunnel(config, serverId),
+          this.hasDeviceSupport() ? new cordova.plugins.outline.Tunnel(serverId, config.proxy) :
+                                    new FakeOutlineTunnel(serverId, config.proxy),
           eventQueue);
     };
   }

--- a/src/www/app/electron_main.ts
+++ b/src/www/app/electron_main.ts
@@ -94,8 +94,8 @@ main({
     return (serverId: string, config: ServerConfig, eventQueue: EventQueue) => {
       return new OutlineServer(
           serverId, config,
-          isOsSupported ? new ElectronOutlineTunnel(config, serverId) :
-                          new FakeOutlineTunnel(config, serverId),
+          isOsSupported ? new ElectronOutlineTunnel(serverId, config.proxy) :
+                          new FakeOutlineTunnel(serverId, config.proxy),
           eventQueue);
     };
   },

--- a/src/www/app/fake_tunnel.ts
+++ b/src/www/app/fake_tunnel.ts
@@ -13,9 +13,9 @@
 // limitations under the License.
 
 import * as errors from '../model/errors';
-import {ShadowsocksConfig} from '../model/shadowsocks';
+import {ShadowsocksConfig, ShadowsocksConfigSource} from '../model/shadowsocks';
 
-import {Tunnel, TunnelStatus} from './tunnel';
+import {ProxyConfigResponse, Tunnel, TunnelStatus} from './tunnel';
 
 // Fake Tunnel implementation for demoing and testing.
 // Note that because this implementation does not emit disconnection events, "switching" between
@@ -23,14 +23,30 @@ import {Tunnel, TunnelStatus} from './tunnel';
 export class FakeOutlineTunnel implements Tunnel {
   private running = false;
 
-  constructor(public config: ShadowsocksConfig, public id: string) {}
+  constructor(public id: string, public config?: ShadowsocksConfig) {}
 
   private playBroken() {
-    return this.config.name?.toLowerCase().includes('broken');
+    return this.config ?.name ?.toLowerCase().includes('broken');
   }
 
   private playUnreachable() {
-    return this.config.name?.toLowerCase().includes('unreachable');
+    return this.config ?.name ?.toLowerCase().includes('unreachable');
+  }
+
+  async fetchProxyConfig(source: ShadowsocksConfigSource): Promise<ProxyConfigResponse> {
+    if (!source) {
+      throw new errors.IllegalServerConfiguration();
+    }
+    return {
+      statusCode: 200,
+      proxies: [{
+        host: '127.0.0.1',
+        port: 1080,
+        password: 'test',
+        method: 'chacha20-ietf-poly1305',
+        name: 'Dynamic Server'
+      }]
+    };
   }
 
   async start(): Promise<void> {

--- a/src/www/app/main.ts
+++ b/src/www/app/main.ts
@@ -54,21 +54,15 @@ function createServerRepo(
     if (repo.getAll().length === 0) {
       repo.add({
         name: 'Fake Working Server',
-        host: '127.0.0.1',
-        port: 123,
-        method: 'chacha20-ietf-poly1305'
+        proxy: {host: '127.0.0.1', port: 123, method: 'chacha20-ietf-poly1305'}
       });
       repo.add({
         name: 'Fake Broken Server',
-        host: '192.0.2.1',
-        port: 123,
-        method: 'chacha20-ietf-poly1305'
+        proxy: {host: '192.0.2.1', port: 123, method: 'chacha20-ietf-poly1305'}
       });
       repo.add({
         name: 'Fake Unreachable Server',
-        host: '10.0.0.24',
-        port: 123,
-        method: 'chacha20-ietf-poly1305'
+        proxy: {host: '10.0.0.24', port: 123, method: 'chacha20-ietf-poly1305'}
       });
     }
   }

--- a/src/www/app/outline_server.ts
+++ b/src/www/app/outline_server.ts
@@ -75,8 +75,12 @@ export class OutlineServer implements PersistentServer {
       if (this.config.source) {
         console.log(`fetching proxy config`);
         const response = await this.tunnel.fetchProxyConfig(this.config.source);
-        if (response.statusCode >= 400 || !response.proxies) {
-          throw new Error(`failed to fetch proxy config with status code ${response.statusCode}`);
+        if (response.statusCode >= 400) {
+          console.error(`failed to fetch proxy config with status code ${response.statusCode}`);
+          throw new errors.HttpError(response.statusCode);
+        } else if (!response.proxies || response.proxies.length === 0) {
+          console.error(`received empty proxy config list`);
+          throw new errors.UnsupportedServerConfiguration();
         }
         if (response.redirectUrl && isPermanentRedirect(response.statusCode)) {
           this.eventQueue.enqueue(

--- a/src/www/app/persistent_server.spec.ts
+++ b/src/www/app/persistent_server.spec.ts
@@ -1,0 +1,81 @@
+// Copyright 2020 The Outline Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {InMemoryStorage} from '../infrastructure/memory_storage';
+import {ServerConfig} from '../model/server';
+
+import {ConfigById, ConfigByIdV0, migrateServerConfigStorageToV1, PersistentServerRepository} from './persistent_server';
+
+// TODO(alalama): unit tests for PersistentServerRepository
+
+describe('migrateServerConfigStorageToV1', () => {
+  it('migrates storage to V1', () => {
+    const config0: ShadowsocksConfig = {
+      host: '127.0.0.1',
+      port: 1080,
+      password: 'test',
+      method: 'chacha20-ietf-poly1305',
+      name: 'fake server 0'
+    };
+    const config1: ShadowsocksConfig = {
+      host: '127.0.0.1',
+      port: 1089,
+      password: 'test',
+      method: 'chacha20-ietf-poly1305',
+      name: 'fake server 1'
+    };
+    const configByIdV0: ConfigByIdV0 = {'server-0': config0, 'server-1': config1};
+    const configByIdV0Json = JSON.stringify(configByIdV0);
+    const storage = new InMemoryStorage(
+        new Map([[PersistentServerRepository.SERVERS_STORAGE_KEY_V0, configByIdV0Json]]));
+
+    migrateServerConfigStorageToV1(storage);
+
+    const configByIdV1Json = storage.getItem(PersistentServerRepository.SERVERS_STORAGE_KEY);
+    expect(configByIdV1Json).toBeDefined();
+    const configByIdV1: ConfigById = JSON.parse(configByIdV1Json || '');
+    expect(configByIdV1['server-0'].proxy).toEqual(configByIdV0['server-0']);
+    expect(configByIdV1['server-0'].name).toEqual(configByIdV0['server-0'].name);
+    expect(configByIdV1['server-1'].proxy).toEqual(configByIdV0['server-1']);
+    expect(configByIdV1['server-1'].name).toEqual(configByIdV0['server-1'].name);
+  });
+
+  it('loads migrated V1 servers', () => {
+    const config0: ServerConfig = {
+      proxy: {
+        host: '127.0.0.1',
+        port: 1080,
+        password: 'test',
+        method: 'chacha20-ietf-poly1305',
+        name: 'server 0'
+      },
+      name: 'server 0'
+    };
+    const config1: ServerConfig = {
+      proxy: {host: '127.0.0.1', port: 1089, password: 'test', method: 'chacha20-ietf-poly1305'},
+      name: 'server 1'
+    };
+    const configByIdV1: ConfigById = {'server-0': config0, 'server-1': config1};
+    const configByIdV0Json = JSON.stringify(configByIdV1);
+    const storage = new InMemoryStorage(
+        new Map([[PersistentServerRepository.SERVERS_STORAGE_KEY, configByIdV0Json]]));
+
+    migrateServerConfigStorageToV1(storage);
+
+    const configByIdV1Json = storage.getItem(PersistentServerRepository.SERVERS_STORAGE_KEY);
+    expect(configByIdV1Json).toBeDefined();
+    const configByIdV1Storage: ConfigById = JSON.parse(configByIdV1Json || '');
+    expect(configByIdV1Storage).toEqual(configByIdV1);
+  });
+});

--- a/src/www/app/settings.spec.ts
+++ b/src/www/app/settings.spec.ts
@@ -12,7 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import {InMemoryStorage} from '../infrastructure/memory_storage';
+
 import {Settings, SettingsKey} from './settings';
+
+const FAKE_SETTINGS_KEYS = ['key', 'key1', 'key2'];
 
 describe('Settings', () => {
   it('sets and gets settings', () => {
@@ -81,34 +85,3 @@ describe('Settings', () => {
     }).toThrowError(SyntaxError);
   });
 });
-
-const FAKE_SETTINGS_KEYS = ['key', 'key1', 'key2'];
-
-class InMemoryStorage implements Storage {
-  // Not implemented: only for the Storage interface.
-  readonly length = 0;
-  [key: string]: {};
-  [index: number]: string;
-
-  constructor(private store: Map<string, string> = new Map<string, string>()) {}
-
-  clear(): void {
-    throw new Error('InMemoryStorage.clear not implemented');
-  }
-
-  getItem(key: string): string|null {
-    return this.store.get(key) || null;
-  }
-
-  key(index: number): string|null {
-    throw new Error('InMemoryStorage.key not implemented');
-  }
-
-  removeItem(key: string): void {
-    throw new Error('InMemoryStorage.removeItem not implemented');
-  }
-
-  setItem(key: string, data: string): void {
-    this.store.set(key, data);
-  }
-}

--- a/src/www/app/tunnel.ts
+++ b/src/www/app/tunnel.ts
@@ -12,12 +12,24 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {ShadowsocksConfig} from '../../www/model/shadowsocks';
+import {ShadowsocksConfig, ShadowsocksConfigSource} from '../../www/model/shadowsocks';
 
 export const enum TunnelStatus {
   CONNECTED,
   DISCONNECTED,
   RECONNECTING
+}
+
+// Response to a `ShadowsocksConfigSource` HTTP request.
+export interface ProxyConfigResponse {
+  // HTTP status code.
+  statusCode: number;
+
+  // Set after successfully retrieving and parsing the proxy configuration list.
+  proxies?: ShadowsocksConfig[];
+
+  // Set when the server responds with a HTTP redirect (3xx) code.
+  redirectUrl?: string;
 }
 
 // Represents a VPN tunnel to a Shadowsocks proxy server. Implementations provide native tunneling
@@ -27,7 +39,12 @@ export interface Tunnel {
   readonly id: string;
 
   // Shadowsocks proxy configuration.
-  config: ShadowsocksConfig;
+  config?: ShadowsocksConfig;
+
+  // Retrieves one or more proxy configurations from the proxy configuration source.
+  // Throws if `source` is not present or if there is an error retrieving
+  // the proxy configuration.
+  fetchProxyConfig(source: ShadowsocksConfigSource): Promise<ProxyConfigResponse>;
 
   // Connects a VPN, routing all device traffic to a Shadowsocks server as dictated by `config`.
   // If there is another running instance, broadcasts a disconnect event and stops the active

--- a/src/www/infrastructure/memory_storage.ts
+++ b/src/www/infrastructure/memory_storage.ts
@@ -1,0 +1,41 @@
+// Copyright 2020 The Outline Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+export class InMemoryStorage implements Storage {
+  readonly length = 0;
+  [key: string]: {};
+  [index: number]: string;
+
+  constructor(private store: Map<string, string> = new Map<string, string>()) {}
+
+  clear(): void {
+    throw new Error('InMemoryStorage.clear not implemented');
+  }
+
+  getItem(key: string): string|null {
+    return this.store.get(key) || null;
+  }
+
+  key(index: number): string|null {
+    throw new Error('InMemoryStorage.key not implemented');
+  }
+
+  removeItem(key: string): void {
+    this.store.delete(key);
+  }
+
+  setItem(key: string, data: string): void {
+    this.store.set(key, data);
+  }
+}

--- a/src/www/model/errors.ts
+++ b/src/www/model/errors.ts
@@ -92,6 +92,14 @@ export class ServerUnreachable extends RegularNativeError {}
 export class IllegalServerConfiguration extends RegularNativeError {}
 export class NoAdminPermissions extends RegularNativeError {}
 export class SystemConfigurationException extends RegularNativeError {}
+export class UnsupportedServerConfiguration extends RegularNativeError {}
+export class TlsCertificateError extends RegularNativeError {}
+export class DomainResolutionError extends RegularNativeError {}
+export class HttpError extends RegularNativeError {
+  constructor(public statusCode = 500) {
+    super();
+  }
+}
 
 //////
 // Now, "unexpected" errors.
@@ -112,7 +120,6 @@ export class VpnStartFailure extends RedFlagNativeError {}
 //  - cordova-plugin-outline/outlinePlugin.js#ERROR_CODE
 //  - cordova-plugin-outline/android/java/org/outline/OutlinePlugin.java#ErrorCode
 //
-// TODO: Is it safe to re-use values here, i.e. is native node rebuilt in step with the TypeScript?
 export const enum ErrorCode {
   // TODO: NO_ERROR is weird. Only used internally by the Android plugin?
   NO_ERROR = 0,
@@ -128,7 +135,11 @@ export const enum ErrorCode {
   CONFIGURE_SYSTEM_PROXY_FAILURE = 9,
   NO_ADMIN_PERMISSIONS = 10,
   UNSUPPORTED_ROUTING_TABLE = 11,
-  SYSTEM_MISCONFIGURED = 12
+  SYSTEM_MISCONFIGURED = 12,
+  DNS_RESOLUTION_ERROR = 13,
+  TLS_CERTIFICATE_ERROR = 14,
+  HTTP_ERROR = 15,
+  UNSUPPORTED_SERVER_CONFIGURATION = 16
 }
 
 // Converts an ErrorCode - originating in "native" code - to an instance of the relevant
@@ -160,6 +171,12 @@ export function fromErrorCode(errorCode: ErrorCode): NativeError {
       return new UnsupportedRoutingTable();
     case ErrorCode.SYSTEM_MISCONFIGURED:
       return new SystemConfigurationException();
+    case ErrorCode.DNS_RESOLUTION_ERROR:
+      return new DomainResolutionError();
+    case ErrorCode.TLS_CERTIFICATE_ERROR:
+      return new TlsCertificateError();
+    case ErrorCode.HTTP_ERROR:
+      return new HttpError();
     default:
       throw new Error(`unknown ErrorCode ${errorCode}`);
   }
@@ -192,6 +209,12 @@ export function toErrorCode(e: NativeError): ErrorCode {
     return ErrorCode.NO_ADMIN_PERMISSIONS;
   } else if (e instanceof SystemConfigurationException) {
     return ErrorCode.SYSTEM_MISCONFIGURED;
+  } else if (e instanceof DomainResolutionError) {
+    return ErrorCode.DNS_RESOLUTION_ERROR;
+  } else if (e instanceof TlsCertificateError) {
+    return ErrorCode.TLS_CERTIFICATE_ERROR;
+  } else if (e instanceof HttpError) {
+    return ErrorCode.HTTP_ERROR;
   }
   throw new Error(`unknown NativeError ${e.name}`);
 }

--- a/src/www/model/events.ts
+++ b/src/www/model/events.ts
@@ -46,6 +46,10 @@ export class ServerReconnecting implements OutlineEvent {
   constructor(public readonly server: Server) {}
 }
 
+export class ServerConfigSourceUrlChanged implements OutlineEvent {
+  constructor(public readonly server: Server, public readonly url: string) {}
+}
+
 // Simple publisher-subscriber queue.
 export class EventQueue {
   private queuedEvents: OutlineEvent[] = [];

--- a/src/www/model/server.ts
+++ b/src/www/model/server.ts
@@ -12,16 +12,19 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {ShadowsocksConfig} from './shadowsocks';
+import {ShadowsocksConfig, ShadowsocksConfigSource} from './shadowsocks';
 
 // TODO: add guidelines for this file
 
 export interface Server {
   // A unique id that identifies this Server.
-  id: string;
+  readonly id: string;
 
   // The name of this server, as given by the user.
   name: string;
+
+  // Domain name or IP address, and port of the server.
+  readonly host: string;
 
   // The message identifier corresponding to the server error state. This identifier
   // must match one of the localized app message.
@@ -40,10 +43,21 @@ export interface Server {
   checkReachable(): Promise<boolean>;
 }
 
-export type ServerConfig = ShadowsocksConfig;
+
+export interface ServerConfig {
+  // Static proxy configuration.
+  readonly proxy?: ShadowsocksConfig;
+
+  // Dynamic proxy configuration retrieval source.
+  source?: ShadowsocksConfigSource;
+
+  // User-given name.
+  name?: string;
+}
 
 export interface ServerRepository {
   add(serverConfig: ServerConfig): void;
+  update(serverId: string, newConfig: ServerConfig): void;
   forget(serverId: string): void;
   undoForget(serverId: string): void;
   getAll(): Server[];

--- a/src/www/model/shadowsocks.ts
+++ b/src/www/model/shadowsocks.ts
@@ -20,3 +20,8 @@ export interface ShadowsocksConfig {
   method?: string;
   name?: string;
 }
+
+// Endpoint to retrieve Shadowsocks proxy configurations.
+export interface ShadowsocksConfigSource {
+  url: string;
+}

--- a/src/www/ui_components/add-server-view.html
+++ b/src/www/ui_components/add-server-view.html
@@ -157,13 +157,14 @@
         <div class="title">[[localize('server-add-access-key')]]</div>
         <div class="faded">[[localize('server-add-instructions')]]</div>
       </div>
+      <!-- TODO(alalama): display https://? -->
       <paper-input
         id="accessKeyInput"
         class="shadow"
         label="[[localize('server-access-key-label', 'ssProtocol', 'ss://')]]"
         no-label-float
         value="{{accessKey}}"
-        pattern="((ss://)|(https://s3\.amazonaws\.com/outline-vpn/((index\.html.*[#].*/invite/)|(invite\.html.*[#]))ss)).*"
+        pattern="((ss://)|(https://)).*"
       >
         <iron-icon icon="communication:vpn-key" slot="suffix"></iron-icon>
       </paper-input>

--- a/src/www/ui_components/server-card.html
+++ b/src/www/ui_components/server-card.html
@@ -57,6 +57,7 @@
 
       .card-header {
         display: flex;
+        justify-content: space-between;
       }
 
       .card-content {
@@ -72,7 +73,8 @@
         flex: 1;
         padding: 16px 0 0 16px;
         font-size: 20px;
-        /* Make the IP address copyable */
+        max-width: 66%;
+        /* Make the sever name and host copyable */
         -webkit-user-select: text; /* Safari */
         -ms-user-select: text; /* IE/Edge */
         user-select: text; /* Chrome */
@@ -86,6 +88,8 @@
       #serverHost {
         color: rgba(0, 0, 0, 0.54);
         font-size: small;
+        overflow: hidden;
+        text-overflow: ellipsis;
       }
 
       #server-visualization-button {
@@ -155,7 +159,7 @@
         ></server-connection-viz>
         <div id="serverInfo">
           <div id="serverName">[[serverName]]</div>
-          <div id="serverHost">[[serverHost]]:[[serverPort]]</div>
+          <div id="serverHost">[[serverHost]]</div>
         </div>
         <paper-menu-button horizontal-align="right" close-on-activate="true">
           <paper-icon-button icon="icons:more-vert" slot="dropdown-trigger"></paper-icon-button>
@@ -206,7 +210,6 @@
         serverName: String,
         serverId: String,
         serverHost: String,
-        serverPort: Number,
         state: {
           type: String,
           value: "DISCONNECTED",

--- a/src/www/ui_components/server-list.html
+++ b/src/www/ui_components/server-list.html
@@ -40,15 +40,10 @@
       }
     </style>
     <template is="dom-repeat" items="[[servers]]">
-      <!--
-        item.host actually calls the getter in OutlineServer instead of accessing .host in ServerConfig.
-        TODO get rid of the .host getter and force users of PersistentServer to all go through the config.
-      -->
       <server-card
         server-id="[[item.id]]"
         server-name="[[item.name]]"
         server-host="[[item.host]]"
-        server-port="[[item.config.port]]"
         error-message="[[localize(item.errorMessageId)]]"
         disabled="[[item.errorMessageId]]"
         localize="[[localize]]"


### PR DESCRIPTION
Implements SIP008 online config in the web app per #891. 

- Refactors `ServerConfig` to include the proxy configuration source. Performs a data migration on local storage.
- The `Tunnel` interface exposes a method, `fetchProxyConfig`, to retrieve the proxy configuration.
  - The `ProxyConfigResponse` type enables the web app to update the configuration source on redirects and surface HTTP status codes.
- `OutlineServer` retrieves the proxy configuration upon connecting.
- The server card UI displays the proxy configuration source for online config servers while disconnected and the proxy configuration host while connected.

TODO
- [ ] Define and localize error messages for fetch proxy config failures.
- [ ] Implement a policy to select a proxy configuration out of many.
- [ ] Decide whether to support `ssconf://` in addtion to `https://`.
- [ ] Decide a default name for online config servers.