### PR TITLE
fix(client/electron/windows): double quote full path of OutlineService

### DIFF
--- a/src/electron/install_windows_service.bat
+++ b/src/electron/install_windows_service.bat
@@ -29,7 +29,7 @@ set PWD=%~dp0%
 
 :: Install and start the service, configuring it to restart on boot.
 :: NOTE: spaces after the arguments are necessary for a correct installation, do not remove!
-%SystemRoot%\System32\sc create OutlineService binpath= "%PWD%OutlineService.exe" displayname= "OutlineService" start= "auto"
+%SystemRoot%\System32\sc create OutlineService binpath= "\"%PWD%OutlineService.exe\"" displayname= "OutlineService" start= "auto"
 %SystemRoot%\System32\net start OutlineService
 
 :: This is for the client: sudo-prompt discards stdout/stderr if the script


### PR DESCRIPTION
Double quote the path of `OutlineService.exe` in Windows service installation script to prevent a potential vulnerability discovered by a user's internal scanner below; in addition, this will also allow us to [add arguments to the service command](https://stackoverflow.com/a/11084834) in the future.

#### References

Unquoted Search Path or Element is vulnerable:

- https://cwe.mitre.org/data/definitions/428.html
- https://isc.sans.edu/diary/Help+eliminate+unquoted+path+vulnerabilities/14464
- http://www.ryanandjeffshow.com/blog/2013/04/11/powershell-fixing-unquoted-service-paths-complete/

