### PR TITLE
chore(www): add `meaning` attribute to messages with updated placeholders

### DIFF
--- a/resources/original_messages.json
+++ b/resources/original_messages.json
@@ -77,7 +77,7 @@
   },
   "contact_view_exit_connection": {
     "description": "Message shown to users who are trying to contact support about an unsupported issue.",
-    "meaning": "Message shown to users who are trying to contact support about an unsupported issue.",
+    "meaning": "MsgID-20240319-UpdateWhenPlaceHolderChanged",
     "message": "The Outline team is not able to assist with connecting to a server. Please try the troubleshooting steps listed $START_OF_LINK$here$END_OF_LINK$ and then contact the person who gave you the access key to troubleshoot this issue.",
     "placeholders": {
       "END_OF_LINK": {
@@ -90,7 +90,7 @@
   },
   "contact_view_exit_no_server": {
     "description": "Message shown to users who are trying to contact support about an unsupported issue.",
-    "meaning": "Message shown to users who are trying to contact support about an unsupported issue.",
+    "meaning": "MsgID-20240319-UpdateWhenPlaceHolderChanged",
     "message": "The Outline team does not distribute free or paid access keys. $START_OF_LINK$Learn more about how to get an access key.$END_OF_LINK$",
     "placeholders": {
       "END_OF_LINK": {

--- a/resources/original_messages.json
+++ b/resources/original_messages.json
@@ -77,6 +77,7 @@
   },
   "contact_view_exit_connection": {
     "description": "Message shown to users who are trying to contact support about an unsupported issue.",
+    "meaning": "Message shown to users who are trying to contact support about an unsupported issue.",
     "message": "The Outline team is not able to assist with connecting to a server. Please try the troubleshooting steps listed $START_OF_LINK$here$END_OF_LINK$ and then contact the person who gave you the access key to troubleshoot this issue.",
     "placeholders": {
       "END_OF_LINK": {
@@ -89,6 +90,7 @@
   },
   "contact_view_exit_no_server": {
     "description": "Message shown to users who are trying to contact support about an unsupported issue.",
+    "meaning": "Message shown to users who are trying to contact support about an unsupported issue.",
     "message": "The Outline team does not distribute free or paid access keys. $START_OF_LINK$Learn more about how to get an access key.$END_OF_LINK$",
     "placeholders": {
       "END_OF_LINK": {


### PR DESCRIPTION
#1924 updated the placeholders of an existing message, without changing the message ID. This is a problem in the Translation Console as it can mess up existing translations that are based on a single placeholder. Here I'm changing the message ID by adding the `meaning` attribute, as suggested.