### PR TITLE
fix(build): fix Outline Client build in Windows

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -111,7 +111,7 @@
         "karma-webpack": "^5.0.0",
         "minimist": "^1.2.6",
         "node-fetch": "^3.3.0",
-        "node-gyp": "^10.0.1",
+        "node-gyp": "^10.1.0",
         "outline-i18n": "Jigsaw-Code/outline-i18n#v0.0.7",
         "postcss": "^7.0.39",
         "postcss-rtl": "^1.7.3",
@@ -22480,9 +22480,9 @@
       }
     },
     "node_modules/node-gyp": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-10.0.1.tgz",
-      "integrity": "sha512-gg3/bHehQfZivQVfqIyy8wTdSymF9yTyP4CJifK73imyNMU8AIGQE2pUa7dNWfmMeG9cDVF2eehiRMv0LC1iAg==",
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-10.1.0.tgz",
+      "integrity": "sha512-B4J5M1cABxPc5PwfjhbV5hoy2DP9p8lFXASnEN6hugXOa61416tnTZ29x9sSwAd0o99XNIcpvDDy1swAExsVKA==",
       "dev": true,
       "dependencies": {
         "env-paths": "^2.2.0",
@@ -49444,9 +49444,9 @@
       "integrity": "sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA=="
     },
     "node-gyp": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-10.0.1.tgz",
-      "integrity": "sha512-gg3/bHehQfZivQVfqIyy8wTdSymF9yTyP4CJifK73imyNMU8AIGQE2pUa7dNWfmMeG9cDVF2eehiRMv0LC1iAg==",
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-10.1.0.tgz",
+      "integrity": "sha512-B4J5M1cABxPc5PwfjhbV5hoy2DP9p8lFXASnEN6hugXOa61416tnTZ29x9sSwAd0o99XNIcpvDDy1swAExsVKA==",
       "dev": true,
       "requires": {
         "env-paths": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -120,7 +120,7 @@
     "karma-webpack": "^5.0.0",
     "minimist": "^1.2.6",
     "node-fetch": "^3.3.0",
-    "node-gyp": "^10.0.1",
+    "node-gyp": "^10.1.0",
     "outline-i18n": "Jigsaw-Code/outline-i18n#v0.0.7",
     "postcss": "^7.0.39",
     "postcss-rtl": "^1.7.3",

--- a/src/infrastructure/electron/app_paths.ts
+++ b/src/infrastructure/electron/app_paths.ts
@@ -43,5 +43,9 @@ export function getAppPath() {
 }
 
 export function pathToEmbeddedBinary(filename: string) {
-  return path.join(unpackedAppPath(), 'output', 'build', os.platform(), filename + (isWindows ? '.exe' : ''));
+  let osName = os.platform().toString(); /* should be either 'linux' or 'win32' */
+  if (osName === 'win32') {
+    osName = 'windows';
+  }
+  return path.join(unpackedAppPath(), 'output', 'build', osName, filename + (isWindows ? '.exe' : ''));
 }

--- a/src/tun2socks/build.action.mjs
+++ b/src/tun2socks/build.action.mjs
@@ -36,7 +36,7 @@ export async function main(...parameters) {
       'go',
       'build',
       '-o',
-      `output/build/${targetPlatform}/tun2socks`,
+      `output/build/${targetPlatform}/tun2socks${targetPlatform === 'windows' ? '.exe' : ''}`,
       'github.com/Jigsaw-Code/outline-client/src/tun2socks/outline/electron'
     );
   }


### PR DESCRIPTION
This PR fixes a `node-gyp` build error of Outline Client for Windows by upgrading it to the latest version.

And the `tun2socks` not found runtime error caused by the wrong path of the file.