### PR TITLE
fix(client/electron/windows): force `eol=crlf` for Windows installation scripts

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,14 @@
 * text=auto eol=lf
+
+# Windows Batch Script
 *.bat eol=crlf
+
+# NSIS Installation Script
+*.nsh eol=crlf
+
+# Tap Driver Installation Script
+third_party/tap-windows6/bin/*.inf eol=crlf
+third_party/tap-windows6/bin/*.h eol=crlf
+
 # Allow the build folders to be searched by GitHub's T file search
 build/** linguist-generated=false


### PR DESCRIPTION
This fixes #1988 .

(I guess I will need to renormalize the line endings once it's getting merged?)