### PR TITLE
fix(client/electron): update electron's tun2socks paths built by taskfile

### DIFF
--- a/client/infrastructure/electron/app_paths.ts
+++ b/client/infrastructure/electron/app_paths.ts
@@ -43,9 +43,22 @@ export function getAppPath() {
   return electronAppPath;
 }
 
-export function pathToEmbeddedBinary(filename: string) {
+export function pathToEmbeddedTun2socksBinary() {
   return path.join(
     unpackedAppPath(), 'client', 'output', 'build',
     (isWindows ? 'windows' : 'linux'),
-    filename + (isWindows ? '.exe' : ''));
+    'tun2socks' + (isWindows ? '.exe' : ''));
+}
+
+/**
+ * Get the parent directory path containing the background service binaries.
+ * On Windows, this folder contains `OutlineService.exe`.
+ * While on Linux this folder contains `outline_proxy_controller`.
+ * @returns A string representing the path of the directory that contains service binaries.
+ */
+export function pathToEmbeddedOutlineService() {
+  if (isWindows) {
+    return getAppPath();
+  }
+  return path.join(unpackedAppPath(), 'client', 'tools', 'outline_proxy_controller', 'dist');
 }

--- a/client/infrastructure/electron/app_paths.ts
+++ b/client/infrastructure/electron/app_paths.ts
@@ -44,9 +44,8 @@ export function getAppPath() {
 }
 
 export function pathToEmbeddedBinary(filename: string) {
-  let osName = os.platform().toString(); /* should be either 'linux' or 'win32' */
-  if (osName === 'win32') {
-    osName = 'windows';
-  }
-  return path.join(unpackedAppPath(), 'output', 'build', osName, filename + (isWindows ? '.exe' : ''));
+  return path.join(
+    unpackedAppPath(), 'client', 'output', 'build',
+    (isWindows ? 'windows' : 'linux'),
+    filename + (isWindows ? '.exe' : ''));
 }

--- a/src/electron/electron-builder.json
+++ b/src/electron/electron-builder.json
@@ -1,6 +1,6 @@
 {
   "files": ["build/electron", "client/www", "client/resources/tray", "!node_modules/electron"],
-  "asarUnpack": ["output", "tools"],
+  "asarUnpack": ["client", "tools"],
   "artifactName": "Outline-Client.${ext}",
   "directories": {
     "output": "output/build/dist"
@@ -10,7 +10,7 @@
       "target": "AppImage",
       "arch": ["x64"]
     },
-    "files": ["build/icons/png", "output/build/linux", "tools/outline_proxy_controller/dist"],
+    "files": ["build/icons/png", "client/output/build/linux", "tools/outline_proxy_controller/dist"],
     "icon": "build/icons/png",
     "category": "Network"
   },
@@ -21,7 +21,7 @@
         "arch": "ia32"
       }
     ],
-    "files": ["output/build/windows"],
+    "files": ["client/output/build/windows"],
     "icon": "build/icons/win/icon.ico",
     "sign": "src/electron/windows/electron_builder_signing_plugin.cjs",
     "signingHashAlgorithms": ["sha256"]

--- a/src/electron/electron-builder.json
+++ b/src/electron/electron-builder.json
@@ -1,6 +1,6 @@
 {
   "files": ["build/electron", "client/www", "client/resources/tray", "!node_modules/electron"],
-  "asarUnpack": ["client", "tools"],
+  "asarUnpack": ["client"],
   "artifactName": "Outline-Client.${ext}",
   "directories": {
     "output": "output/build/dist"
@@ -10,7 +10,7 @@
       "target": "AppImage",
       "arch": ["x64"]
     },
-    "files": ["build/icons/png", "client/output/build/linux", "tools/outline_proxy_controller/dist"],
+    "files": ["build/icons/png", "client/output/build/linux", "client/tools/outline_proxy_controller/dist"],
     "icon": "build/icons/png",
     "category": "Network"
   },

--- a/src/electron/go_vpn_tunnel.ts
+++ b/src/electron/go_vpn_tunnel.ts
@@ -19,7 +19,7 @@ import {powerMonitor} from 'electron';
 import {ChildProcessHelper, ProcessTerminatedExitCodeError, ProcessTerminatedSignalError} from './process';
 import {RoutingDaemon} from './routing_service';
 import {VpnTunnel} from './vpn_tunnel';
-import {pathToEmbeddedBinary} from '../../client/infrastructure/electron/app_paths';
+import {pathToEmbeddedTun2socksBinary} from '../../client/infrastructure/electron/app_paths';
 import {ShadowsocksSessionConfig} from '../../client/src/www/app/tunnel';
 import {TunnelStatus} from '../../client/src/www/app/tunnel';
 import {ErrorCode, fromErrorCode, UnexpectedPluginError} from '../../client/src/www/model/errors';
@@ -222,7 +222,7 @@ class GoTun2socks {
   private readonly process: ChildProcessHelper;
 
   constructor(private readonly config: ShadowsocksSessionConfig) {
-    this.process = new ChildProcessHelper(pathToEmbeddedBinary('tun2socks'));
+    this.process = new ChildProcessHelper(pathToEmbeddedTun2socksBinary());
   }
 
   async start(isUdpEnabled: boolean): Promise<void> {
@@ -259,7 +259,7 @@ class GoTun2socks {
         if (data?.toString().includes('tun2socks running')) {
           console.debug('tun2socks started');
           autoRestart = true;
-          this.process.onStdErr = null;
+          this.process.onStdErr = undefined;
         }
       };
       try {

--- a/src/electron/routing_service.ts
+++ b/src/electron/routing_service.ts
@@ -20,7 +20,7 @@ import * as path from 'path';
 import * as fsextra from 'fs-extra';
 import * as sudo from 'sudo-prompt';
 
-import {getAppPath} from '../../client/infrastructure/electron/app_paths';
+import {pathToEmbeddedOutlineService} from '../../client/infrastructure/electron/app_paths';
 import {TunnelStatus} from '../../client/src/www/app/tunnel';
 import {ErrorCode, SystemConfigurationException} from '../../client/src/www/model/errors';
 
@@ -67,7 +67,7 @@ enum RoutingServiceStatusCode {
 //  - Linux: systemctl start|stop outline_proxy_controller.service
 //  - Windows: net start|stop OutlineService
 export class RoutingDaemon {
-  private socket: Socket | undefined;
+  private socket: Socket | null | undefined;
 
   private stopping = false;
 
@@ -182,7 +182,7 @@ export class RoutingDaemon {
 
   private async writeReset() {
     return new Promise<void>((resolve, reject) => {
-      const written = this.socket.write(
+      const written = this.socket?.write(
         JSON.stringify({action: RoutingServiceAction.RESET_ROUTING, parameters: {}} as RoutingServiceRequest),
         err => {
           if (err) {
@@ -262,12 +262,11 @@ function installWindowsRoutingServices(): Promise<void> {
   //   build/windows
   //
   // Surrounding quotes important, consider "c:\program files"!
-  const script = `"${path.join(getAppPath(), WINDOWS_INSTALLER_FILENAME)}"`;
+  const script = `"${path.join(pathToEmbeddedOutlineService(), WINDOWS_INSTALLER_FILENAME)}"`;
   return executeCommandAsRoot(script);
 }
 
 async function installLinuxRoutingServices(): Promise<void> {
-  const OUTLINE_PROXY_CONTROLLER_PATH = path.join('tools', 'outline_proxy_controller', 'dist');
   const LINUX_INSTALLER_FILENAME = 'install_linux_service.sh';
   const installationFileDescriptors: Array<{filename: string; executable: boolean; sha256: string}> = [
     {filename: LINUX_INSTALLER_FILENAME, executable: true, sha256: ''},
@@ -276,7 +275,7 @@ async function installLinuxRoutingServices(): Promise<void> {
   ];
 
   // These Linux service files are located in a mounted folder of the AppImage, typically
-  // located at /tmp/.mount_Outlinxxxxxx/resources/. These files can only be acceeded by
+  // located at /tmp/.mount_Outlinxxxxxx/resources/. These files can only be accessed by
   // the user who launched Outline.AppImage, so even root cannot access the files or folders.
   // Therefore we have to copy these files to a normal temporary folder, and execute them
   // as root.
@@ -290,7 +289,7 @@ async function installLinuxRoutingServices(): Promise<void> {
   // - https://github.com/AppImage/AppImageKit/issues/146
   // - https://xwartz.gitbooks.io/electron-gitbook/content/en/tutorial/application-packaging.html
   const tmp = await fsextra.mkdtemp('/tmp/');
-  const srcFolderPath = path.join(getAppPath(), OUTLINE_PROXY_CONTROLLER_PATH);
+  const srcFolderPath = pathToEmbeddedOutlineService();
 
   console.log(`copying service installation files to ${tmp}`);
   for (const descriptor of installationFileDescriptors) {


### PR DESCRIPTION
This PR fixes several path issues in electron caused by the recent source code movement and output path change in #1967 .