### PR TITLE
fix(manager): remove duplicate message

### DIFF
--- a/server_manager/messages/master_messages.json
+++ b/server_manager/messages/master_messages.json
@@ -1361,10 +1361,6 @@
     "description": "Item in a dropdown menu to select the cloud provider that the user is contacting support about.",
     "message": "Google Cloud"
   },
-  "support_form_cloud_provider_other": {
-    "description": "Item in a dropdown menu to select an unknown cloud provider that the user is contacting support about.",
-    "message": "Other"
-  },
   "support_form_cloud_provider": {
     "description": "Label of a Contact Support form input field.",
     "message": "Cloud Provider"

--- a/server_manager/web_app/ui_components/outline-support-form.ts
+++ b/server_manager/web_app/ui_components/outline-support-form.ts
@@ -142,7 +142,7 @@ export class OutlineSupportForm extends LitElement {
       })
     /** We should sort the providers by their labels, which may be localized. */
     providers.sort((a, b) => a.label.localeCompare(b.label));
-    providers.push({value: 'other', label: this.localize('support-form-cloud-provider-other')});
+    providers.push({value: 'other', label: this.localize('feedback-other')});
 
     return html`
       <form ${ref(this.formRef)} @submit=${this.submit}>


### PR DESCRIPTION
This breaks the translation console pipeline, as it generates a message with the same ID but with different descriptions.