### PR TITLE
test(client): fix failed tun2socks connectivity_test cases

### DIFF
--- a/.github/workflows/build_and_test_debug_client.yml
+++ b/.github/workflows/build_and_test_debug_client.yml
@@ -13,7 +13,6 @@ on:
     branches:
       - master
 
-# TODO: run go tests
 jobs:
   web_test:
     name: Web Test
@@ -44,11 +43,27 @@ jobs:
           files: ./client/src/output/coverage/www/coverage-final.json
           flags: unittests, www
 
+  backend_test:
+    name: Go Backend Test
+    runs-on: ubuntu-20.04
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2.3.4
+
+      - name: Install Go
+        uses: actions/setup-go@v4
+        with:
+          go-version-file: '${{ github.workspace }}/go.mod'
+
+      - name: Test Tun2socks Backend
+        run: go test -v -race -bench=. -benchtime=100ms ./client/...
+
   linux_debug_build:
     name: Linux Debug Build
     runs-on: ubuntu-20.04
     timeout-minutes: 20
-    needs: web_test
+    needs: [web_test, backend_test]
     steps:
       - name: Checkout
         uses: actions/checkout@v2.3.4
@@ -75,7 +90,7 @@ jobs:
     name: Windows Debug Build
     runs-on: windows-2019
     timeout-minutes: 20
-    needs: web_test
+    needs: [web_test, backend_test]
     steps:
       - name: Support longpaths
         run: git config --system core.longpaths true
@@ -105,7 +120,7 @@ jobs:
     name: MacOS Debug Build
     runs-on: macos-13
     timeout-minutes: 20
-    needs: web_test
+    needs: [web_test, backend_test]
     steps:
       - name: Display XCode
         run: xcode-select --print-path
@@ -147,7 +162,7 @@ jobs:
     name: iOS Debug Build
     runs-on: macos-13
     timeout-minutes: 20
-    needs: web_test
+    needs: [web_test, backend_test]
     steps:
       - name: Display XCode
         run: xcode-select --print-path
@@ -189,7 +204,7 @@ jobs:
     name: Mac Catalyst Debug Build
     runs-on: macos-13
     timeout-minutes: 20
-    needs: web_test
+    needs: [web_test, backend_test]
     steps:
       - name: Display XCode
         run: xcode-select --print-path
@@ -231,7 +246,7 @@ jobs:
     name: Android Debug Build
     runs-on: ubuntu-20.04
     timeout-minutes: 20
-    needs: web_test
+    needs: [web_test, backend_test]
     steps:
       - name: Checkout
         uses: actions/checkout@v2.3.4

--- a/.github/workflows/build_and_test_debug_client.yml
+++ b/.github/workflows/build_and_test_debug_client.yml
@@ -57,7 +57,7 @@ jobs:
           go-version-file: '${{ github.workspace }}/go.mod'
 
       - name: Test Tun2socks Backend
-        run: go test -v -race -bench=. -benchtime=100ms ./client/...
+        run: go test -race -bench=. -benchtime=100ms ./client/...
 
   linux_debug_build:
     name: Linux Debug Build

--- a/client/src/tun2socks/outline/connectivity/connectivity_test.go
+++ b/client/src/tun2socks/outline/connectivity/connectivity_test.go
@@ -79,7 +79,7 @@ type fakeSSClient struct {
 	failUDP            bool
 }
 
-func (c *fakeSSClient) Dial(_ context.Context, raddr string) (transport.StreamConn, error) {
+func (c *fakeSSClient) DialStream(_ context.Context, raddr string) (transport.StreamConn, error) {
 	if c.failReachability {
 		return nil, &net.OpError{}
 	}


### PR DESCRIPTION
This PR fixed "`fakeSSClient` does not implement `StreamDialer`" compilation error in `connectivity_test.go`.

I also added Go test to the CI workflow so we can catch similar errors in the future.