### PR TITLE
feat(client/electron): propagate structured errors from Go to TypeScript

### DIFF
--- a/client/electron/go_vpn_tunnel.ts
+++ b/client/electron/go_vpn_tunnel.ts
@@ -21,7 +21,7 @@ import {ChildProcessHelper, ProcessTerminatedExitCodeError, ProcessTerminatedSig
 import {RoutingDaemon} from './routing_service';
 import {VpnTunnel} from './vpn_tunnel';
 import {ShadowsocksSessionConfig, TunnelStatus} from '../src/www/app/tunnel';
-import {ErrorCode, UnexpectedPluginError} from '../src/www/model/errors';
+import {ErrorCode} from '../src/www/model/errors';
 
 const isLinux = platform() === 'linux';
 const isWindows = platform() === 'win32';
@@ -228,7 +228,7 @@ class GoTun2socks {
 
   /**
    * Starts tun2socks process, and waits for it to launch successfully.
-   * Success is confirmed when the phrase "tun2socks started" is detected in the `stdout`.
+   * Success is confirmed when the phrase "tun2socks running" is detected in the `stdout`.
    * Otherwise, an error containing a JSON-formatted message will be thrown.
    * @param isUdpEnabled Indicates whether the remote Shadowsocks server supports UDP.
    */

--- a/client/electron/index.ts
+++ b/client/electron/index.ts
@@ -450,11 +450,17 @@ function main() {
     mainWindow?.webContents.send('outline-ipc-push-clipboard');
   });
 
-  // Connects to the specified server.
+  // Connects to a proxy server specified by a config.
+  //
+  // If any issues occur, an Error will be thrown, which you can try-catch around
+  // `ipcRenderer.invoke`. But you should avoid depending on the specific error type.
+  // Instead, you should use its message property (which would probably be a JSON representation
+  // of a PlatformError). See https://github.com/electron/electron/issues/24427.
+  //
   // TODO: refactor channel name and namespace to a constant
   ipcMain.handle(
     'outline-ipc-start-proxying',
-    async (_, args: {config: ShadowsocksSessionConfig; id: string}): Promise<string | null> => {
+    async (_, args: {config: ShadowsocksSessionConfig; id: string}): Promise<void> => {
       // TODO: Rather than first disconnecting, implement a more efficient switchover (as well as
       //       being faster, this would help prevent traffic leaks - the Cordova clients already do
       //       this).
@@ -480,16 +486,11 @@ function main() {
         tunnelStore.save(args).catch(() => {
           console.error('Failed to store tunnel.');
         });
-
-        return null;
       } catch (e) {
-        console.error(`could not connect: ${e.name} (${e.message})`);
+        console.error('could not connect:', e);
         // clean up the state, no need to await because stopVpn might throw another error which can be ignored
         stopVpn();
-        if (!(e?.message ?? '')) {
-          return `unexpected error of type ${e.name}`;
-        }
-        return e.message;
+        throw e;
       }
     }
   );

--- a/client/electron/index.ts
+++ b/client/electron/index.ts
@@ -24,7 +24,7 @@ import autoLaunch = require('auto-launch'); // tslint:disable-line
 import {app, BrowserWindow, ipcMain, Menu, MenuItemConstructorOptions, nativeImage, shell, Tray} from 'electron';
 import {autoUpdater} from 'electron-updater';
 
-import {lookupIp} from "./connectivity";
+import {lookupIp} from './connectivity';
 import {GoVpnTunnel} from './go_vpn_tunnel';
 import {installRoutingServices, RoutingDaemon} from './routing_service';
 import {TunnelStore, SerializableTunnel} from './tunnel_store';
@@ -142,7 +142,7 @@ function setupWindow(): void {
   // The ideal solution would be: either electron-builder supports the app icon; or we add
   // dpi-aware features to this app.
   if (isLinux) {
-    mainWindow.setIcon(path.join(app.getAppPath(), 'output', 'client', 'electron', 'icons', 'png', '64x64.png'));
+    mainWindow.setIcon(path.join(app.getAppPath(), 'client', 'electron', 'icons', 'png', '64x64.png'));
   }
 
   const pathToIndexHtml = path.join(app.getAppPath(), 'client', 'www', 'index_electron.html');
@@ -454,7 +454,7 @@ function main() {
   // TODO: refactor channel name and namespace to a constant
   ipcMain.handle(
     'outline-ipc-start-proxying',
-    async (_, args: {config: ShadowsocksSessionConfig; id: string}): Promise<errors.ErrorCode> => {
+    async (_, args: {config: ShadowsocksSessionConfig; id: string}): Promise<string | null> => {
       // TODO: Rather than first disconnecting, implement a more efficient switchover (as well as
       //       being faster, this would help prevent traffic leaks - the Cordova clients already do
       //       this).
@@ -481,12 +481,15 @@ function main() {
           console.error('Failed to store tunnel.');
         });
 
-        return errors.ErrorCode.NO_ERROR;
+        return null;
       } catch (e) {
         console.error(`could not connect: ${e.name} (${e.message})`);
         // clean up the state, no need to await because stopVpn might throw another error which can be ignored
         stopVpn();
-        return errors.toErrorCode(e);
+        if (!(e?.message ?? '')) {
+          return `unexpected error of type ${e.name}`;
+        }
+        return e.message;
       }
     }
   );

--- a/client/electron/preload.ts
+++ b/client/electron/preload.ts
@@ -39,21 +39,37 @@ export class ElectronRendererMethodChannel {
    * We need to have a namespace due to security consideration:
    *   - https://www.electronjs.org/docs/latest/tutorial/context-isolation#security-considerations
    */
-  public constructor(private readonly namespace: string) {}
+  constructor(private readonly namespace: string) {}
 
-  public readonly send = (channel: string, ...args: unknown[]): void =>
+  readonly send = (channel: string, ...args: unknown[]): void =>
     ipcRenderer.send(`${this.namespace}-${channel}`, ...args);
 
   // TODO: replace the `any` with a better type once we unify the IPC call framework
   /* eslint-disable  @typescript-eslint/no-explicit-any */
-  public readonly invoke = (channel: string, ...args: unknown[]): Promise<any> =>
-    ipcRenderer.invoke(`${this.namespace}-${channel}`, ...args);
+  readonly invoke = async (channel: string, ...args: unknown[]): Promise<any> => {
+    const ipcName = `${this.namespace}-${channel}`;
+    try {
+      await ipcRenderer.invoke(ipcName, ...args);
+    } catch (e) {
+      // Normalize the error message to what's being thrown in the IPC itself
+      //   e.message == "Error invoking remote method 'xxx': Error: <actual message>"
+      // https://github.com/electron/electron/blob/v31.0.0/lib/renderer/api/ipc-renderer.ts#L22
+      if (typeof e?.message === 'string') {
+        const errPrefix = `'${ipcName}': Error: `;
+        const prefixIndex = e.message.indexOf(errPrefix);
+        if (prefixIndex >= 0) {
+          e.message = e.message.substring(prefixIndex + errPrefix.length);
+        }
+      }
+      throw e;
+    }
+  };
 
-  public readonly on = (channel: string, listener: (e: IpcRendererEvent, ...args: unknown[]) => void): void => {
+  readonly on = (channel: string, listener: (e: IpcRendererEvent, ...args: unknown[]) => void): void => {
     ipcRenderer.on(`${this.namespace}-${channel}`, listener);
   };
 
-  public readonly once = (channel: string, listener: (e: IpcRendererEvent, ...args: unknown[]) => void): void => {
+  readonly once = (channel: string, listener: (e: IpcRendererEvent, ...args: unknown[]) => void): void => {
     ipcRenderer.once(`${this.namespace}-${channel}`, listener);
   };
 }

--- a/client/electron/process.ts
+++ b/client/electron/process.ts
@@ -42,7 +42,7 @@ export class ProcessTerminatedSignalError extends Error {
 //       found).
 export class ChildProcessHelper {
   private readonly processName: string;
-  private childProcess?: ChildProcess | null = null;
+  private childProcess?: ChildProcess;
   private waitProcessToExit?: Promise<void>;
 
   /**
@@ -75,7 +75,7 @@ export class ChildProcessHelper {
       const onExit = (code?: number, signal?: string) => {
         if (this.childProcess) {
           this.childProcess.removeAllListeners();
-          this.childProcess = null;
+          this.childProcess = undefined;
         } else {
           // When listening to both the 'exit' and 'error' events, guard against accidentally
           // invoking handler functions multiple times.
@@ -92,8 +92,8 @@ export class ChildProcessHelper {
         }
       };
 
-      this.childProcess!.stdout?.on('data', data => this.stdOutListener?.(data));
-      this.childProcess!.stderr?.on('data', (data?: string | Buffer) => {
+      this.childProcess?.stdout?.on('data', data => this.stdOutListener?.(data));
+      this.childProcess?.stderr?.on('data', (data?: string | Buffer) => {
         if (this.isDebugModeEnabled) {
           // This will be captured by Sentry
           console.error(`[${this.processName} - STDERR]: ${data}`);
@@ -104,14 +104,14 @@ export class ChildProcessHelper {
       if (this.isDebugModeEnabled) {
         // Redirect subprocess output while bypassing the Node console.  This makes sure we don't
         // send web traffic information to Sentry.
-        this.childProcess!.stdout?.pipe(process.stdout);
-        this.childProcess!.stderr?.pipe(process.stderr);
+        this.childProcess?.stdout?.pipe(process.stdout);
+        this.childProcess?.stderr?.pipe(process.stderr);
       }
 
       // We have to listen for both events: error means the process could not be launched and in that
       // case exit will not be invoked.
-      this.childProcess!.on('error', onExit.bind(this));
-      this.childProcess!.on('exit', onExit.bind(this));
+      this.childProcess?.on('error', onExit.bind(this));
+      this.childProcess?.on('exit', onExit.bind(this));
     }));
   }
 

--- a/client/electron/process.ts
+++ b/client/electron/process.ts
@@ -20,8 +20,8 @@ import process from 'node:process';
  * A child process is terminated abnormally, caused by a non-zero exit code.
  */
 export class ProcessTerminatedExitCodeError extends Error {
-  constructor(public readonly exitCode: number, public readonly errJSON: string) {
-    super(`Process terminated by non-zero exit code: ${exitCode}, caused by ${errJSON}`);
+  constructor(readonly exitCode: number, errJSON: string) {
+    super(errJSON);
   }
 }
 
@@ -29,7 +29,7 @@ export class ProcessTerminatedExitCodeError extends Error {
  * A child process is terminated abnormally, caused by a signal string.
  */
 export class ProcessTerminatedSignalError extends Error {
-  constructor(public readonly signal: string) {
+  constructor(readonly signal: string) {
     super(`Process terminated by signal: ${signal}`);
   }
 }

--- a/client/electron/process.ts
+++ b/client/electron/process.ts
@@ -20,8 +20,8 @@ import process from 'node:process';
  * A child process is terminated abnormally, caused by a non-zero exit code.
  */
 export class ProcessTerminatedExitCodeError extends Error {
-  constructor(public readonly exitCode: number) {
-    super(`Process terminated by non-zero exit code: ${exitCode}`);
+  constructor(public readonly exitCode: number, public readonly errJSON: string) {
+    super(`Process terminated by non-zero exit code: ${exitCode}, caused by ${errJSON}`);
   }
 }
 
@@ -42,7 +42,7 @@ export class ProcessTerminatedSignalError extends Error {
 //       found).
 export class ChildProcessHelper {
   private readonly processName: string;
-  private childProcess?: ChildProcess = null;
+  private childProcess?: ChildProcess | null = null;
   private waitProcessToExit?: Promise<void>;
 
   /**
@@ -50,7 +50,7 @@ export class ChildProcessHelper {
    */
   public isDebugModeEnabled = false;
 
-  private stdErrListener?: (data?: string | Buffer) => void;
+  private stdOutListener?: ((data?: string | Buffer) => void) | null;
 
   constructor(private readonly path: string) {
     this.processName = basename(this.path);
@@ -71,6 +71,7 @@ export class ChildProcessHelper {
     }
     this.childProcess = spawn(this.path, args);
     return (this.waitProcessToExit = new Promise((resolve, reject) => {
+      let stdErrJSON = '';
       const onExit = (code?: number, signal?: string) => {
         if (this.childProcess) {
           this.childProcess.removeAllListeners();
@@ -85,33 +86,37 @@ export class ChildProcessHelper {
         if (code === 0) {
           resolve();
         } else if (code) {
-          reject(new ProcessTerminatedExitCodeError(code));
+          reject(new ProcessTerminatedExitCodeError(code, stdErrJSON));
         } else {
-          reject(new ProcessTerminatedSignalError(signal));
+          reject(new ProcessTerminatedSignalError(signal ?? 'unknown'));
         }
       };
 
-      const onStdErr = (data?: string | Buffer) => {
+      const onStdOut = (data?: string | Buffer) => {
         if (this.isDebugModeEnabled) {
-          console.error(`[STDERR - ${this.processName}]: ${data}`);
+          console.info(`[${this.processName} - STDOUT]: ${data}`);
         }
-        if (this.stdErrListener) {
-          this.stdErrListener(data);
-        }
+        this.stdOutListener?.(data);
       };
-      this.childProcess.stderr.on('data', onStdErr.bind(this));
+      this.childProcess!.stdout?.on('data', onStdOut.bind(this));
+      this.childProcess!.stderr?.on('data', (data?: string | Buffer) => {
+        if (this.isDebugModeEnabled) {
+          console.error(`[${this.processName} - STDERR]: ${data}`);
+        }
+        stdErrJSON += data?.toString() ?? '';
+      });
 
       if (this.isDebugModeEnabled) {
         // Redirect subprocess output while bypassing the Node console.  This makes sure we don't
         // send web traffic information to Sentry.
-        this.childProcess.stdout.pipe(process.stdout);
-        this.childProcess.stderr.pipe(process.stderr);
+        this.childProcess!.stdout?.pipe(process.stdout);
+        this.childProcess!.stderr?.pipe(process.stderr);
       }
 
       // We have to listen for both events: error means the process could not be launched and in that
       // case exit will not be invoked.
-      this.childProcess.on('error', onExit.bind(this));
-      this.childProcess.on('exit', onExit.bind(this));
+      this.childProcess!.on('error', onExit.bind(this));
+      this.childProcess!.on('exit', onExit.bind(this));
     }));
   }
 
@@ -121,25 +126,25 @@ export class ChildProcessHelper {
    * If the process does not exist normally (i.e., exit code !== 0 or received a signal), it will
    * throw either `ProcessTerminatedExitCodeError` or `ProcessTerminatedSignalError`.
    */
-  stop(): Promise<void> {
+  async stop(): Promise<void> {
     if (!this.childProcess) {
       // Never started.
       return;
     }
     this.childProcess.kill();
-    return this.waitProcessToExit;
+    return await this.waitProcessToExit;
   }
 
-  set onStdErr(listener: ((data?: string | Buffer) => void) | undefined) {
-    this.stdErrListener = listener;
-    if (!this.stdErrListener && !this.isDebugModeEnabled) {
-      this.childProcess?.stderr.removeAllListeners();
+  set onStdOut(listener: ((data?: string | Buffer) => void) | null) {
+    this.stdOutListener = listener;
+    if (!this.stdOutListener && !this.isDebugModeEnabled) {
+      this.childProcess?.stdout?.removeAllListeners();
     }
   }
 }
 
 function logExit(processName: string, exitCode?: number, signal?: string) {
-  const prefix = `[EXIT - ${processName}]: `;
+  const prefix = `[${processName} - EXIT]: `;
   if (exitCode !== null) {
     const log = exitCode === 0 ? console.log : console.error;
     log(`${prefix}Exited with code ${exitCode}`);

--- a/client/electron/process.ts
+++ b/client/electron/process.ts
@@ -92,15 +92,10 @@ export class ChildProcessHelper {
         }
       };
 
-      const onStdOut = (data?: string | Buffer) => {
-        if (this.isDebugModeEnabled) {
-          console.info(`[${this.processName} - STDOUT]: ${data}`);
-        }
-        this.stdOutListener?.(data);
-      };
-      this.childProcess!.stdout?.on('data', onStdOut.bind(this));
+      this.childProcess!.stdout?.on('data', data => this.stdOutListener?.(data));
       this.childProcess!.stderr?.on('data', (data?: string | Buffer) => {
         if (this.isDebugModeEnabled) {
+          // This will be captured by Sentry
           console.error(`[${this.processName} - STDERR]: ${data}`);
         }
         stdErrJSON += data?.toString() ?? '';

--- a/client/src/tun2socks/outline/electron/main.go
+++ b/client/src/tun2socks/outline/electron/main.go
@@ -136,6 +136,7 @@ func main() {
 		}
 	}()
 
+	// This message is used in TypeScript to determine whether tun2socks has been started successfully
 	logger.Info("tun2socks running...")
 
 	osSignals := make(chan os.Signal, 1)

--- a/client/src/tun2socks/outline/electron/main.go
+++ b/client/src/tun2socks/outline/electron/main.go
@@ -18,17 +18,17 @@ import (
 	"flag"
 	"fmt"
 	"io"
+	"log/slog"
 	"os"
 	"os/signal"
 	"strings"
 	"syscall"
 	"time"
 
-	"github.com/Jigsaw-Code/outline-apps/client/src/tun2socks/outline/internal/utf8"
 	"github.com/Jigsaw-Code/outline-apps/client/src/tun2socks/outline/neterrors"
+	"github.com/Jigsaw-Code/outline-apps/client/src/tun2socks/outline/platerrors"
 	"github.com/Jigsaw-Code/outline-apps/client/src/tun2socks/outline/shadowsocks"
 	"github.com/Jigsaw-Code/outline-apps/client/src/tun2socks/outline/tun2socks"
-	"github.com/eycorsican/go-tun2socks/common/log"
 	_ "github.com/eycorsican/go-tun2socks/common/log/simple" // Register a simple logger.
 	"github.com/eycorsican/go-tun2socks/core"
 	"github.com/eycorsican/go-tun2socks/proxy/dnsfallback"
@@ -40,6 +40,8 @@ const (
 	udpTimeout = 30 * time.Second
 	persistTun = true // Linux: persist the TUN interface after the last open file descriptor is closed.
 )
+
+var logger = slog.New(slog.NewTextHandler(os.Stdout, nil))
 
 var args struct {
 	tunAddr *string
@@ -63,8 +65,13 @@ var args struct {
 	version           *bool
 }
 var version string // Populated at build time through `-X main.version=...`
-var lwipWriter io.Writer
 
+// This app sets up a local network stack to handle requests from a tun device.
+//
+// If the app runs successfully, it exits with code 0.
+// If there's an error, it exits with code 1 and prints a detailed error message in JSON format to stderr.
+//
+// The app also prints logs, but these are not meant to be read by the parent process.
 func main() {
 	args.tunAddr = flag.String("tunAddr", "10.0.85.2", "TUN interface IP address")
 	args.tunGw = flag.String("tunGw", "10.0.85.1", "TUN interface gateway")
@@ -93,25 +100,18 @@ func main() {
 
 	client, err := newShadowsocksClientFromArgs()
 	if err != nil {
-		log.Errorf("Failed to create Shadowsocks client: %v", err)
-		os.Exit(neterrors.IllegalConfiguration.Number())
+		printErrorAndExit(err, 1)
 	}
 
 	if *args.checkConnectivity {
-		connErrCode, err := shadowsocks.CheckConnectivity(client)
-		log.Debugf("Connectivity checks error code: %v", connErrCode)
-		if err != nil {
-			log.Errorf("Failed to perform connectivity checks: %v", err)
-		}
-		os.Exit(connErrCode)
+		checkConnectivityAndExit(client)
 	}
 
 	// Open TUN device
 	dnsResolvers := strings.Split(*args.tunDNS, ",")
 	tunDevice, err := tun.OpenTunDevice(*args.tunName, *args.tunAddr, *args.tunGw, *args.tunMask, dnsResolvers, persistTun)
 	if err != nil {
-		log.Errorf("Failed to open TUN device: %v", err)
-		os.Exit(neterrors.SystemMisconfigured.Number())
+		printErrorAndExit(platerrors.NewWithCause(platerrors.SetupSystemVPNFailed, "failed to open TUN device", err), 1)
 	}
 	// Output packets to TUN device
 	core.RegisterOutputFn(tunDevice.Write)
@@ -120,7 +120,7 @@ func main() {
 	core.RegisterTCPConnHandler(tun2socks.NewTCPHandler(client))
 	if *args.dnsFallback {
 		// UDP connectivity not supported, fall back to DNS over TCP.
-		log.Debugf("Registering DNS fallback UDP handler")
+		logger.Debug("Registering DNS fallback UDP handler")
 		core.RegisterUDPConnHandler(dnsfallback.NewUDPHandler())
 	} else {
 		core.RegisterUDPConnHandler(tun2socks.NewUDPHandler(client, udpTimeout))
@@ -131,34 +131,40 @@ func main() {
 	go func() {
 		_, err := io.CopyBuffer(lwipWriter, tunDevice, make([]byte, mtu))
 		if err != nil {
-			log.Errorf("Failed to write data to network stack: %v", err)
-			os.Exit(neterrors.Unexpected.Number())
+			printErrorAndExit(platerrors.NewWithCause(platerrors.DataTransmissionFailed,
+				"failed to write data to network stack", err), 1)
 		}
 	}()
 
-	log.Infof("tun2socks running...")
+	logger.Info("tun2socks running...")
 
 	osSignals := make(chan os.Signal, 1)
 	signal.Notify(osSignals, os.Interrupt, os.Kill, syscall.SIGTERM, syscall.SIGHUP)
 	sig := <-osSignals
-	log.Debugf("Received signal: %v", sig)
+	logger.Debug("Received signal", sig)
 }
 
 func setLogLevel(level string) {
+	slvl := slog.LevelInfo
 	switch strings.ToLower(level) {
 	case "debug":
-		log.SetLevel(log.DEBUG)
+		slvl = slog.LevelDebug
 	case "info":
-		log.SetLevel(log.INFO)
+		slvl = slog.LevelInfo
 	case "warn":
-		log.SetLevel(log.WARN)
+		slvl = slog.LevelWarn
 	case "error":
-		log.SetLevel(log.ERROR)
+		slvl = slog.LevelError
 	case "none":
-		log.SetLevel(log.NONE)
-	default:
-		log.SetLevel(log.INFO)
+		logger = slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{Level: slog.LevelError}))
+		return
 	}
+	logger = slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slvl}))
+}
+
+func printErrorAndExit(err error, exitCode int) {
+	fmt.Fprintln(os.Stderr, err.Error())
+	os.Exit(exitCode)
 }
 
 // newShadowsocksClientFromArgs creates a new shadowsocks.Client instance
@@ -174,13 +180,33 @@ func newShadowsocksClientFromArgs() (*shadowsocks.Client, error) {
 			CipherName: *args.proxyCipher,
 			Password:   *args.proxyPassword,
 		}
-		if prefixStr := *args.proxyPrefix; len(prefixStr) > 0 {
-			if p, err := utf8.DecodeUTF8CodepointsToRawBytes(prefixStr); err != nil {
-				return nil, fmt.Errorf("Failed to parse prefix string: %w", err)
-			} else {
-				config.Prefix = p
-			}
+		prefixBytes, err := shadowsocks.ParseConfigPrefixFromString(*args.proxyPrefix)
+		if err != nil {
+			return nil, err
 		}
+		config.Prefix = prefixBytes
 		return shadowsocks.NewClient(&config)
 	}
+}
+
+// checkConnectivity checks whether the remote Shadowsocks server supports TCP or UDP,
+// and converts the neterrors to a PlatformError.
+// TODO: remove this function once we migrated CheckConnectivity to return a PlatformError.
+func checkConnectivityAndExit(c *shadowsocks.Client) {
+	connErrCode, err := shadowsocks.CheckConnectivity(c)
+	if err != nil {
+		printErrorAndExit(platerrors.NewWithCause(platerrors.InternalError, "failed to check connectivity", err), 1)
+	}
+	switch connErrCode {
+	case neterrors.NoError.Number():
+		os.Exit(0)
+	case neterrors.AuthenticationFailure.Number():
+		printErrorAndExit(platerrors.New(platerrors.Unauthenticated, "authentication failed"), 1)
+	case neterrors.Unreachable.Number():
+		printErrorAndExit(platerrors.New(platerrors.ProxyServerUnreachable, "cannot connect to Shadowsocks server"), 1)
+	case neterrors.UDPConnectivity.Number():
+		printErrorAndExit(platerrors.New(platerrors.ProxyServerUDPUnsupported, "Shadowsocks server does not support UDP"),
+			neterrors.UDPConnectivity.Number())
+	}
+	printErrorAndExit(platerrors.New(platerrors.InternalError, "failed to check connectivity"), 1)
 }

--- a/client/src/tun2socks/outline/platerrors/doc.go
+++ b/client/src/tun2socks/outline/platerrors/doc.go
@@ -1,0 +1,25 @@
+// Copyright 2024 The Outline Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/*
+Package platerrors defines types, constants, and functions related to platform-specific errors
+that originate from the platform's native network code.
+
+This package is designed to facilitate platform error communication across language boundaries
+in Outline Client, particularly between Go and TypeScript.
+
+By using this package, Go code can effectively transmit detailed error to TypeScript, where the
+[PlatformError] is converted into a TypeScript equivalent type for seamless handling.
+*/
+package platerrors

--- a/client/src/tun2socks/outline/platerrors/error_code.go
+++ b/client/src/tun2socks/outline/platerrors/error_code.go
@@ -51,24 +51,40 @@ const (
 const (
 	// ResolveIPFailed means that we failed to resolve the IP address of a hostname.
 	ResolveIPFailed ErrorCode = "ERR_NET_RESOLVE_IP"
+
+	// ServerUnreachable means we failed to establish a connection to a remote server.
+	ServerUnreachable ErrorCode = "ERR_SERVER_UNREACHABLE"
+
+	// Unauthenticated indicates that the client failed to communicate with a remote server
+	// due to the lack of valid authentication credentials.
+	Unauthenticated ErrorCode = "ERR_CLIENT_UNAUTHENTICATED"
 )
 
 // Shadowsocks network error codes
 
 const (
+	// SSIllegalConfig indicates an invalid config to connect to a Shadowsocks server.
+	SSIllegalConfig ErrorCode = "ERR_SHADOWSOCKS_ILLEGAL_CONFIG"
+
 	// SSStreamDialerFailed means we failed to create a Shadowsocks StreamDialer.
 	SSStreamDialerFailed ErrorCode = "ERR_SHADOWSOCKS_NEW_STREAM_DIALER"
 
 	// SSPacketListenerFailed means we failed to create a Shadowsocks PacketListener.
 	SSPacketListenerFailed ErrorCode = "ERR_SHADOWSOCKS_NEW_PACKET_LISTENER"
+
+	// SSTCPConnectFailed means we failed to do a TCP connectivity test against the Shadowsocks server.
+	SSTCPConnectFailed ErrorCode = "ERR_SHADOWSOCKS_TCP_CONNECT"
+
+	// SSUDPUnsupported indicates that a Shadowsocks server does not support UDP.
+	SSUDPUnsupported ErrorCode = "ERR_SHADOWSOCKS_UDP_NOT_SUPPORTED"
 )
 
-// Transport config error codes
+// I/O device error codes
 
 const (
-	IllegalConfigHost     ErrorCode = "ERR_ILLEGAL_CONFIG_HOST"
-	IllegalConfigPort     ErrorCode = "ERR_ILLEGAL_CONFIG_PORT"
-	IllegalConfigCipher   ErrorCode = "ERR_ILLEGAL_CONFIG_CIPHER"
-	IllegalConfigPassword ErrorCode = "ERR_ILLEGAL_CONFIG_PASSWORD"
-	IllegalConfigPrefix   ErrorCode = "ERR_ILLEGAL_CONFIG_PREFIX"
+	// OpenTunDeviceFailed means we failed to open a specific tun/tap device.
+	OpenTunDeviceFailed ErrorCode = "ERR_OPEN_TUN"
+
+	// DeviceCopyDataFailed means we failed to copy data from one device to another.
+	DeviceCopyDataFailed ErrorCode = "ERR_IO_COPY_DATA"
 )

--- a/client/src/tun2socks/outline/platerrors/error_code.go
+++ b/client/src/tun2socks/outline/platerrors/error_code.go
@@ -1,0 +1,74 @@
+// Copyright 2024 The Outline Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package platerrors
+
+// ErrorCode can be used to identify the specific type of a [PlatformError].
+// All possible ErrorCodes are defined as constants in this package.
+// You can reliably use these values in TypeScript to check for specific errors.
+type ErrorCode string
+
+// Internal error codes
+
+const (
+	// GoError represents a general error in Go that is not a [PlatformError].
+	// It is typically the last error in the chain of the causes in a [PlatformError].
+	// This error code is for internal use only. You should not use it to create a [PlatformError]
+	// in your Go code.
+	GoError ErrorCode = "ERR_GOLANG_ERROR"
+
+	// InvalidLogic indicates a development mistake that should be identified and
+	// corrected during the development process. It should not be expected to occur in production.
+	// Typically this error code is for internal use only. You should not use it to create a
+	// [PlatformError] in your Go code.
+	InvalidLogic ErrorCode = "ERR_INVALID_LOGIC"
+)
+
+// Common error codes
+
+const (
+	// IllegalArgument indicates that the caller (usually from TypeScript code) passed an
+	// illegal argument to a native Go function.
+	IllegalArgument ErrorCode = "ERR_ILLEGAL_ARGUMENT"
+
+	// IllegalJSONString means that a string is not a valid JSON string.
+	IllegalJSONString ErrorCode = "ERR_ILLEGAL_JSON_STRING"
+)
+
+// Common network error codes
+
+const (
+	// ResolveIPFailed means that we failed to resolve the IP address of a hostname.
+	ResolveIPFailed ErrorCode = "ERR_NET_RESOLVE_IP"
+)
+
+// Shadowsocks network error codes
+
+const (
+	// SSStreamDialerFailed means we failed to create a Shadowsocks StreamDialer.
+	SSStreamDialerFailed ErrorCode = "ERR_SHADOWSOCKS_NEW_STREAM_DIALER"
+
+	// SSPacketListenerFailed means we failed to create a Shadowsocks PacketListener.
+	SSPacketListenerFailed ErrorCode = "ERR_SHADOWSOCKS_NEW_PACKET_LISTENER"
+)
+
+// Transport config error codes
+
+const (
+	IllegalConfigHost     ErrorCode = "ERR_ILLEGAL_CONFIG_HOST"
+	IllegalConfigPort     ErrorCode = "ERR_ILLEGAL_CONFIG_PORT"
+	IllegalConfigCipher   ErrorCode = "ERR_ILLEGAL_CONFIG_CIPHER"
+	IllegalConfigPassword ErrorCode = "ERR_ILLEGAL_CONFIG_PASSWORD"
+	IllegalConfigPrefix   ErrorCode = "ERR_ILLEGAL_CONFIG_PREFIX"
+)

--- a/client/src/tun2socks/outline/platerrors/error_code.go
+++ b/client/src/tun2socks/outline/platerrors/error_code.go
@@ -19,7 +19,9 @@ package platerrors
 // You can reliably use these values in TypeScript to check for specific errors.
 type ErrorCode string
 
+//////////
 // Internal error codes
+//////////
 
 const (
 	// GoError represents a general error in Go that is not a [PlatformError].
@@ -35,56 +37,45 @@ const (
 	InvalidLogic ErrorCode = "ERR_INVALID_LOGIC"
 )
 
-// Common error codes
-
-const (
-	// IllegalArgument indicates that the caller (usually from TypeScript code) passed an
-	// illegal argument to a native Go function.
-	IllegalArgument ErrorCode = "ERR_ILLEGAL_ARGUMENT"
-
-	// IllegalJSONString means that a string is not a valid JSON string.
-	IllegalJSONString ErrorCode = "ERR_ILLEGAL_JSON_STRING"
-)
-
-// Common network error codes
+//////////
+// Common error codes - network
+//////////
 
 const (
 	// ResolveIPFailed means that we failed to resolve the IP address of a hostname.
-	ResolveIPFailed ErrorCode = "ERR_NET_RESOLVE_IP"
+	ResolveIPFailed ErrorCode = "ERR_RESOLVE_IP_FAILURE"
+)
 
-	// ServerUnreachable means we failed to establish a connection to a remote server.
-	ServerUnreachable ErrorCode = "ERR_SERVER_UNREACHABLE"
+//////////
+// Common error codes - I/O device
+//////////
+
+const (
+	// SetupTrafficHandlerFailed means we failed to setup the traffic handler for a protocol.
+	SetupTrafficHandlerFailed ErrorCode = "ERR_TRAFFIC_HANDLER_SETUP_FAILURE"
+)
+
+//////////
+// Business logic error codes - proxy server
+//////////
+
+const (
+	// ProxyServerUnreachable means we failed to establish a connection to a remote server.
+	ProxyServerUnreachable ErrorCode = "ERR_PROXY_SERVER_UNREACHABLE"
 
 	// Unauthenticated indicates that the client failed to communicate with a remote server
 	// due to the lack of valid authentication credentials.
 	Unauthenticated ErrorCode = "ERR_CLIENT_UNAUTHENTICATED"
 )
 
-// Shadowsocks network error codes
+//////////
+// Business logic error codes - config
+//////////
 
 const (
-	// SSIllegalConfig indicates an invalid config to connect to a Shadowsocks server.
-	SSIllegalConfig ErrorCode = "ERR_SHADOWSOCKS_ILLEGAL_CONFIG"
+	// FetchConfigFailed means we failed to fetch a config from a remote location.
+	FetchConfigFailed ErrorCode = "ERR_FETCH_REMOTE_CONFIG_FAILURE"
 
-	// SSStreamDialerFailed means we failed to create a Shadowsocks StreamDialer.
-	SSStreamDialerFailed ErrorCode = "ERR_SHADOWSOCKS_NEW_STREAM_DIALER"
-
-	// SSPacketListenerFailed means we failed to create a Shadowsocks PacketListener.
-	SSPacketListenerFailed ErrorCode = "ERR_SHADOWSOCKS_NEW_PACKET_LISTENER"
-
-	// SSTCPConnectFailed means we failed to do a TCP connectivity test against the Shadowsocks server.
-	SSTCPConnectFailed ErrorCode = "ERR_SHADOWSOCKS_TCP_CONNECT"
-
-	// SSUDPUnsupported indicates that a Shadowsocks server does not support UDP.
-	SSUDPUnsupported ErrorCode = "ERR_SHADOWSOCKS_UDP_NOT_SUPPORTED"
-)
-
-// I/O device error codes
-
-const (
-	// OpenTunDeviceFailed means we failed to open a specific tun/tap device.
-	OpenTunDeviceFailed ErrorCode = "ERR_OPEN_TUN"
-
-	// DeviceCopyDataFailed means we failed to copy data from one device to another.
-	DeviceCopyDataFailed ErrorCode = "ERR_IO_COPY_DATA"
+	// IllegalConfig indicates an invalid config to connect to a remote server.
+	IllegalConfig ErrorCode = "ERR_ILLEGAL_CONFIG"
 )

--- a/client/src/tun2socks/outline/platerrors/error_code.go
+++ b/client/src/tun2socks/outline/platerrors/error_code.go
@@ -14,6 +14,11 @@
 
 package platerrors
 
+//////////
+// Error code definitions that will be shared across language boundaries.
+// Update corresponding values in "platform_error.ts" when modifying.
+//////////
+
 // ErrorCode can be used to identify the specific type of a [PlatformError].
 // All possible ErrorCodes are defined as constants in this package.
 // You can reliably use these values in TypeScript to check for specific errors.
@@ -74,7 +79,7 @@ const (
 
 const (
 	// FetchConfigFailed means we failed to fetch a config from a remote location.
-	FetchConfigFailed ErrorCode = "ERR_FETCH_REMOTE_CONFIG_FAILURE"
+	FetchConfigFailed ErrorCode = "ERR_FETCH_CONFIG_FAILURE"
 
 	// IllegalConfig indicates an invalid config to connect to a remote server.
 	IllegalConfig ErrorCode = "ERR_ILLEGAL_CONFIG"

--- a/client/src/tun2socks/outline/platerrors/error_code.go
+++ b/client/src/tun2socks/outline/platerrors/error_code.go
@@ -38,6 +38,15 @@ const (
 )
 
 //////////
+// Common error codes - general
+//////////
+
+const (
+	// InternalError represents a general unknown internal service error.
+	InternalError ErrorCode = "ERR_UNKNOWN_INTERNAL_ERROR"
+)
+
+//////////
 // Common error codes - network
 //////////
 
@@ -53,6 +62,12 @@ const (
 const (
 	// SetupTrafficHandlerFailed means we failed to setup the traffic handler for a protocol.
 	SetupTrafficHandlerFailed ErrorCode = "ERR_TRAFFIC_HANDLER_SETUP_FAILURE"
+
+	// SetupSystemVPNFailed means we failed to configure the system VPN to route to us.
+	SetupSystemVPNFailed ErrorCode = "ERR_SYSTEM_VPN_SETUP_FAILURE"
+
+	// DataTransmissionFailed means we failed to copy data from one device to another.
+	DataTransmissionFailed ErrorCode = "ERR_DATA_TRANSMISSION_FAILURE"
 )
 
 //////////
@@ -66,6 +81,9 @@ const (
 	// Unauthenticated indicates that the client failed to communicate with a remote server
 	// due to the lack of valid authentication credentials.
 	Unauthenticated ErrorCode = "ERR_CLIENT_UNAUTHENTICATED"
+
+	// ProxyServerUDPUnsupported means the remote proxy doesn't support relaying UDP traffic.
+	ProxyServerUDPUnsupported ErrorCode = "ERR_PROXY_SERVER_UDP_NOT_SUPPORTED"
 )
 
 //////////

--- a/client/src/tun2socks/outline/platerrors/error_code.go
+++ b/client/src/tun2socks/outline/platerrors/error_code.go
@@ -20,30 +20,12 @@ package platerrors
 type ErrorCode string
 
 //////////
-// Internal error codes
-//////////
-
-const (
-	// GoError represents a general error in Go that is not a [PlatformError].
-	// It is typically the last error in the chain of the causes in a [PlatformError].
-	// This error code is for internal use only. You should not use it to create a [PlatformError]
-	// in your Go code.
-	GoError ErrorCode = "ERR_GOLANG_ERROR"
-
-	// InvalidLogic indicates a development mistake that should be identified and
-	// corrected during the development process. It should not be expected to occur in production.
-	// Typically this error code is for internal use only. You should not use it to create a
-	// [PlatformError] in your Go code.
-	InvalidLogic ErrorCode = "ERR_INVALID_LOGIC"
-)
-
-//////////
 // Common error codes - general
 //////////
 
 const (
-	// InternalError represents a general unknown internal service error.
-	InternalError ErrorCode = "ERR_UNKNOWN_INTERNAL_ERROR"
+	// InternalError represents a general internal service error.
+	InternalError ErrorCode = "ERR_INTERNAL_ERROR"
 )
 
 //////////

--- a/client/src/tun2socks/outline/platerrors/marshal.go
+++ b/client/src/tun2socks/outline/platerrors/marshal.go
@@ -1,0 +1,51 @@
+// Copyright 2024 The Outline Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package platerrors
+
+// platformErrJson is the JSON representation of a [PlatformError].
+type platformErrJSON struct {
+	Code    string           `json:"code"`
+	Message string           `json:"message"`
+	Details string           `json:"details,omitempty"`
+	Cause   *platformErrJSON `json:"cause,omitempty"`
+}
+
+// convertToPlatformErrJSON converts an error into a platformErrJSON.
+func convertToPlatformErrJSON(e error) *platformErrJSON {
+	if e == nil {
+		return nil
+	}
+
+	pe, ok := e.(*PlatformError)
+	if !ok {
+		// We simply return a single JSON object without recursively parsing the wrapped errors,
+		// as they don't provide any additional information beyond the already included error message.
+		return &platformErrJSON{
+			Code:    string(ErrorCodeGoError),
+			Message: e.Error(),
+		}
+	}
+	if pe == nil {
+		// A non-nil interface that contains nil value
+		return nil
+	}
+
+	return &platformErrJSON{
+		Code:    string(pe.Code),
+		Message: pe.Message,
+		Details: pe.Details,
+		Cause:   convertToPlatformErrJSON(pe.Cause),
+	}
+}

--- a/client/src/tun2socks/outline/platerrors/marshal.go
+++ b/client/src/tun2socks/outline/platerrors/marshal.go
@@ -33,7 +33,7 @@ func convertToPlatformErrJSON(e error) *platformErrJSON {
 		// We simply return a single JSON object without recursively parsing the wrapped errors,
 		// as they don't provide any additional information beyond the already included error message.
 		return &platformErrJSON{
-			Code:    string(GoError),
+			Code:    string(InternalError),
 			Message: e.Error(),
 		}
 	}

--- a/client/src/tun2socks/outline/platerrors/marshal.go
+++ b/client/src/tun2socks/outline/platerrors/marshal.go
@@ -33,7 +33,7 @@ func convertToPlatformErrJSON(e error) *platformErrJSON {
 		// We simply return a single JSON object without recursively parsing the wrapped errors,
 		// as they don't provide any additional information beyond the already included error message.
 		return &platformErrJSON{
-			Code:    string(ErrorCodeGoError),
+			Code:    string(GoError),
 			Message: e.Error(),
 		}
 	}

--- a/client/src/tun2socks/outline/platerrors/marshal.go
+++ b/client/src/tun2socks/outline/platerrors/marshal.go
@@ -16,10 +16,10 @@ package platerrors
 
 // platformErrJson is the JSON representation of a [PlatformError].
 type platformErrJSON struct {
-	Code    string           `json:"code"`
-	Message string           `json:"message"`
-	Details string           `json:"details,omitempty"`
-	Cause   *platformErrJSON `json:"cause,omitempty"`
+	Code    string                 `json:"code"`
+	Message string                 `json:"message"`
+	Details map[string]interface{} `json:"details,omitempty"`
+	Cause   *platformErrJSON       `json:"cause,omitempty"`
 }
 
 // convertToPlatformErrJSON converts an error into a platformErrJSON.

--- a/client/src/tun2socks/outline/platerrors/marshal_test.go
+++ b/client/src/tun2socks/outline/platerrors/marshal_test.go
@@ -36,28 +36,28 @@ func TestGoErrorMarshal(t *testing.T) {
 		{
 			name: "General",
 			in:   errors.New("a test error obj"),
-			want: &platformErrJSON{Code: string(ErrorCodeGoError), Message: "a test error obj"},
+			want: &platformErrJSON{Code: string(GoError), Message: "a test error obj"},
 		},
 		{
 			name: "Joined",
 			in:   errors.Join(errors.New("test err 1"), errors.New("test err 2")),
-			want: &platformErrJSON{Code: string(ErrorCodeGoError), Message: "test err 1\ntest err 2"},
+			want: &platformErrJSON{Code: string(GoError), Message: "test err 1\ntest err 2"},
 		},
 		{
 			name: "Formatted",
 			in:   fmt.Errorf("out err: %w", errors.New("inner err")),
-			want: &platformErrJSON{Code: string(ErrorCodeGoError), Message: "out err: inner err"},
+			want: &platformErrJSON{Code: string(GoError), Message: "out err: inner err"},
 		},
 		{
 			name: "MultipleFormatted",
 			in:   fmt.Errorf("lvl3 err: %w %w", errors.New("lvl2 err1"), fmt.Errorf("lvl2 err2: %w", errors.New("lvl1 err"))),
-			want: &platformErrJSON{Code: string(ErrorCodeGoError), Message: "lvl3 err: lvl2 err1 lvl2 err2: lvl1 err"},
+			want: &platformErrJSON{Code: string(GoError), Message: "lvl3 err: lvl2 err1 lvl2 err2: lvl1 err"},
 		},
 		{
 			name: "WrappedPlatformError",
 			in:   fmt.Errorf("should not unwrap: %w", &PlatformError{Code: "ERR_NO_UNWRAP", Message: "Don't unwrap"}),
 			want: &platformErrJSON{
-				Code:    string(ErrorCodeGoError),
+				Code:    string(GoError),
 				Message: `should not unwrap: {"code":"ERR_NO_UNWRAP","message":"Don't unwrap"}`},
 		},
 	}
@@ -98,7 +98,7 @@ func TestPlatformErrorMarshal(t *testing.T) {
 				Code: "ERR_TEST", Message: "test msg", Details: "test details", Cause: errors.New("inner go err")},
 			want: &platformErrJSON{
 				Code: "ERR_TEST", Message: "test msg", Details: "test details",
-				Cause: &platformErrJSON{Code: string(ErrorCodeGoError), Message: "inner go err"}},
+				Cause: &platformErrJSON{Code: string(GoError), Message: "inner go err"}},
 		},
 	}
 

--- a/client/src/tun2socks/outline/platerrors/marshal_test.go
+++ b/client/src/tun2socks/outline/platerrors/marshal_test.go
@@ -1,0 +1,112 @@
+// Copyright 2024 The Outline Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package platerrors
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNilErrorMarshal(t *testing.T) {
+	jsonObj := convertToPlatformErrJSON(nil)
+	require.Nil(t, jsonObj)
+}
+
+func TestGoErrorMarshal(t *testing.T) {
+	tests := []struct {
+		name string
+		in   error
+		want *platformErrJSON
+	}{
+		{
+			name: "General",
+			in:   errors.New("a test error obj"),
+			want: &platformErrJSON{Code: string(ErrorCodeGoError), Message: "a test error obj"},
+		},
+		{
+			name: "Joined",
+			in:   errors.Join(errors.New("test err 1"), errors.New("test err 2")),
+			want: &platformErrJSON{Code: string(ErrorCodeGoError), Message: "test err 1\ntest err 2"},
+		},
+		{
+			name: "Formatted",
+			in:   fmt.Errorf("out err: %w", errors.New("inner err")),
+			want: &platformErrJSON{Code: string(ErrorCodeGoError), Message: "out err: inner err"},
+		},
+		{
+			name: "MultipleFormatted",
+			in:   fmt.Errorf("lvl3 err: %w %w", errors.New("lvl2 err1"), fmt.Errorf("lvl2 err2: %w", errors.New("lvl1 err"))),
+			want: &platformErrJSON{Code: string(ErrorCodeGoError), Message: "lvl3 err: lvl2 err1 lvl2 err2: lvl1 err"},
+		},
+		{
+			name: "WrappedPlatformError",
+			in:   fmt.Errorf("should not unwrap: %w", &PlatformError{Code: "ERR_NO_UNWRAP", Message: "Don't unwrap"}),
+			want: &platformErrJSON{
+				Code:    string(ErrorCodeGoError),
+				Message: `should not unwrap: {"code":"ERR_NO_UNWRAP","message":"Don't unwrap"}`},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := convertToPlatformErrJSON(tc.in)
+			require.NotNil(t, got)
+			require.Nil(t, got.Cause)
+			require.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestPlatformErrorMarshal(t *testing.T) {
+	tests := []struct {
+		name string
+		in   error
+		want *platformErrJSON
+	}{
+		{
+			name: "Single",
+			in:   &PlatformError{Code: "ERR_TEST", Message: "test msg", Details: "test details"},
+			want: &platformErrJSON{Code: "ERR_TEST", Message: "test msg", Details: "test details"},
+		},
+		{
+			name: "Nested",
+			in: &PlatformError{
+				Code: "ERR_TEST", Message: "test msg", Details: "test details",
+				Cause: &PlatformError{Code: "ERR_INNER", Message: "inner msg", Details: "inner details"}},
+			want: &platformErrJSON{
+				Code: "ERR_TEST", Message: "test msg", Details: "test details",
+				Cause: &platformErrJSON{Code: "ERR_INNER", Message: "inner msg", Details: "inner details"}},
+		},
+		{
+			name: "NestedGoError",
+			in: &PlatformError{
+				Code: "ERR_TEST", Message: "test msg", Details: "test details", Cause: errors.New("inner go err")},
+			want: &platformErrJSON{
+				Code: "ERR_TEST", Message: "test msg", Details: "test details",
+				Cause: &platformErrJSON{Code: string(ErrorCodeGoError), Message: "inner go err"}},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := convertToPlatformErrJSON(tc.in)
+			require.NotNil(t, got)
+			require.Equal(t, tc.want, got)
+		})
+	}
+}

--- a/client/src/tun2socks/outline/platerrors/marshal_test.go
+++ b/client/src/tun2socks/outline/platerrors/marshal_test.go
@@ -36,28 +36,28 @@ func TestGoErrorMarshal(t *testing.T) {
 		{
 			name: "General",
 			in:   errors.New("a test error obj"),
-			want: &platformErrJSON{Code: string(GoError), Message: "a test error obj"},
+			want: &platformErrJSON{Code: string(InternalError), Message: "a test error obj"},
 		},
 		{
 			name: "Joined",
 			in:   errors.Join(errors.New("test err 1"), errors.New("test err 2")),
-			want: &platformErrJSON{Code: string(GoError), Message: "test err 1\ntest err 2"},
+			want: &platformErrJSON{Code: string(InternalError), Message: "test err 1\ntest err 2"},
 		},
 		{
 			name: "Formatted",
 			in:   fmt.Errorf("out err: %w", errors.New("inner err")),
-			want: &platformErrJSON{Code: string(GoError), Message: "out err: inner err"},
+			want: &platformErrJSON{Code: string(InternalError), Message: "out err: inner err"},
 		},
 		{
 			name: "MultipleFormatted",
 			in:   fmt.Errorf("lvl3 err: %w %w", errors.New("lvl2 err1"), fmt.Errorf("lvl2 err2: %w", errors.New("lvl1 err"))),
-			want: &platformErrJSON{Code: string(GoError), Message: "lvl3 err: lvl2 err1 lvl2 err2: lvl1 err"},
+			want: &platformErrJSON{Code: string(InternalError), Message: "lvl3 err: lvl2 err1 lvl2 err2: lvl1 err"},
 		},
 		{
 			name: "WrappedPlatformError",
 			in:   fmt.Errorf("should not unwrap: %w", &PlatformError{Code: "ERR_NO_UNWRAP", Message: "Don't unwrap"}),
 			want: &platformErrJSON{
-				Code:    string(GoError),
+				Code:    string(InternalError),
 				Message: `should not unwrap: {"code":"ERR_NO_UNWRAP","message":"Don't unwrap"}`},
 		},
 	}
@@ -98,7 +98,7 @@ func TestPlatformErrorMarshal(t *testing.T) {
 				Code: "ERR_TEST", Message: "test msg", Details: ErrorDetails{"test": "details"}, Cause: errors.New("inner go err")},
 			want: &platformErrJSON{
 				Code: "ERR_TEST", Message: "test msg", Details: makeMapWithPairs("test", "details"),
-				Cause: &platformErrJSON{Code: string(GoError), Message: "inner go err"}},
+				Cause: &platformErrJSON{Code: string(InternalError), Message: "inner go err"}},
 		},
 	}
 

--- a/client/src/tun2socks/outline/platerrors/platform_error.go
+++ b/client/src/tun2socks/outline/platerrors/platform_error.go
@@ -1,0 +1,86 @@
+// Copyright 2024 The Outline Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package platerrors
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// ErrorCode can be used to identify the specific type of a [PlatformError].
+// All possible ErrorCodes are defined as constants in this package.
+// You can reliably use these values in TypeScript to check for specific errors.
+type ErrorCode string
+
+const (
+	// ErrorCodeGoError represents a general error in Go that is not a [PlatformError].
+	// It is typically the last error in the chain of the causes in a [PlatformError].
+	// This error code is for internal use only. You should not use it to create a [PlatformError]
+	// in your Go code.
+	ErrorCodeGoError ErrorCode = "ERR_GOLANG_ERROR"
+
+	// ErrorCodeGoInvalidLogic indicates a development mistake that should be identified and
+	// corrected during the development process. It should not be expected to occur in production.
+	ErrorCodeGoInvalidLogic ErrorCode = "ERR_GOLANG_INVALID_LOGIC"
+)
+
+// PlatformError can be used to communicate error details from Go to TypeScript.
+// It contains details of errors that originate from the native network code.
+//
+// The error might be caused by another PlatformError or a general Go error.
+// A general Go error will be converted to a JSON of [ErrorCodeGoError] with the
+// corresponding error message; and no more wrapped errors will be parsed.
+//
+// Behind the scenes, the error's JSON string can be accessed by Java's Exception.getMessage()
+// and Apple's NSError.localizedDescription through gomobile.
+// It can also be written to stderr for Electron apps or included in responses from a REST API.
+type PlatformError struct {
+	Code             ErrorCode
+	Message, Details string
+	Cause            error
+}
+
+var _ error = (*PlatformError)(nil)
+
+// Error returns a JSON string containing the error details and all its underlying causes,
+// until it finds a cause that is not a [PlatformError].
+// The resulting JSON can be used to reconstruct the error in TypeScript.
+func (e *PlatformError) Error() string {
+	if e == nil {
+		return formatInvalidLogicErrJSON("nil error", "")
+	}
+	if e.Code == "" {
+		return formatInvalidLogicErrJSON("empty error code", "")
+	}
+	errJson, err := json.Marshal(convertToPlatformErrJSON(e))
+	if err != nil {
+		return formatInvalidLogicErrJSON("JSON marshal failure", err.Error())
+	}
+	return string(errJson)
+}
+
+// Unwrap returns the cause of this [PlatformError].
+func (e *PlatformError) Unwrap() error {
+	return e.Cause
+}
+
+// formatInvalidLogicErrJSON creates a JSON string with ErrorCodeGoInvalidLogic, the msg
+// and the details. Please note that msg and details should not contain double quotes.
+// The returned JSON string is compatible with the JSON returned by [PlatformError].Error().
+func formatInvalidLogicErrJSON(msg, details string) string {
+	return fmt.Sprintf(
+		`{"code":"%s","message":"%s","details":"%s"}`,
+		ErrorCodeGoInvalidLogic, msg, details)
+}

--- a/client/src/tun2socks/outline/platerrors/platform_error.go
+++ b/client/src/tun2socks/outline/platerrors/platform_error.go
@@ -83,14 +83,14 @@ func NewWithDetailsCause(code ErrorCode, message string, details ErrorDetails, c
 // The resulting JSON can be used to reconstruct the error in TypeScript.
 func (e *PlatformError) Error() string {
 	if e == nil {
-		return formatInvalidLogicErrJSON("nil error")
+		return formatInternalErrorJSON("nil error")
 	}
 	if e.Code == "" {
-		return formatInvalidLogicErrJSON("empty error code")
+		return formatInternalErrorJSON("empty error code")
 	}
 	errJson, err := json.Marshal(convertToPlatformErrJSON(e))
 	if err != nil {
-		return formatInvalidLogicErrJSON("JSON marshal failure: " + err.Error())
+		return formatInternalErrorJSON("JSON marshal failure: " + err.Error())
 	}
 	return string(errJson)
 }
@@ -100,12 +100,12 @@ func (e *PlatformError) Unwrap() error {
 	return e.Cause
 }
 
-// formatInvalidLogicErrJSON creates a JSON string with ErrorCodeGoInvalidLogic, the msg
-// and the details. Please note that msg and details should not contain double quotes.
+// formatInternalErrorJSON creates a JSON string with ErrorCode InternalError and the msg.
+// Please note that msg should not contain double quotes.
 // The returned JSON string is compatible with the JSON returned by [PlatformError].Error().
-func formatInvalidLogicErrJSON(msg string) string {
+func formatInternalErrorJSON(msg string) string {
 	rmEscapes := strings.NewReplacer("\\", "", "\"", "")
 	return fmt.Sprintf(
 		`{"code":"%s","message":"%s"}`,
-		InvalidLogic, rmEscapes.Replace(msg))
+		InternalError, rmEscapes.Replace(msg))
 }

--- a/client/src/tun2socks/outline/platerrors/platform_error_test.go
+++ b/client/src/tun2socks/outline/platerrors/platform_error_test.go
@@ -34,6 +34,11 @@ func TestPlatformErrorJSONOutput(t *testing.T) {
 			want: `{"code":"ERR_SIMPLE","message":"simple err"}`,
 		},
 		{
+			name: "EmptyDetails",
+			in:   NewWithDetails("ERR_EMPTY_DETAILS", "empty details", ErrorDetails{}),
+			want: `{"code":"ERR_EMPTY_DETAILS","message":"empty details"}`,
+		},
+		{
 			name: "Full",
 			in:   NewWithDetails("ERR_FULL", "full err", ErrorDetails{"full": "details"}),
 			want: `{"code":"ERR_FULL","message":"full err","details":{"full":"details"}}`,

--- a/client/src/tun2socks/outline/platerrors/platform_error_test.go
+++ b/client/src/tun2socks/outline/platerrors/platform_error_test.go
@@ -1,0 +1,95 @@
+// Copyright 2024 The Outline Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package platerrors
+
+import (
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestPlatformErrorJSONOutput(t *testing.T) {
+	tests := []struct {
+		name string
+		in   *PlatformError
+		want string
+	}{
+		{
+			name: "Simple",
+			in:   &PlatformError{Code: "ERR_SIMPLE", Message: "simple err"},
+			want: `{"code":"ERR_SIMPLE","message":"simple err"}`,
+		},
+		{
+			name: "Full",
+			in:   &PlatformError{Code: "ERR_FULL", Message: "full err", Details: "full details"},
+			want: `{"code":"ERR_FULL","message":"full err","details":"full details"}`,
+		},
+		{
+			name: "Nested",
+			in: &PlatformError{
+				Code: "ERR_LVL2", Message: "msg lvl2",
+				Cause: &PlatformError{Code: "ERR_LVL1", Message: "msg lvl1", Details: "details here",
+					Cause: errors.New("go err lvl0")}},
+			want: `{"code":"ERR_LVL2","message":"msg lvl2",` +
+				`"cause":{"code":"ERR_LVL1","message":"msg lvl1","details":"details here",` +
+				`"cause":{"code":"ERR_GOLANG_ERROR","message":"go err lvl0"}}}`,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := tc.in.Error()
+			require.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestPlatformErrorWrapsCause(t *testing.T) {
+	err := &PlatformError{Code: "ERR_WRAP", Message: "should wrap"}
+	require.Nil(t, err.Unwrap())
+
+	inner := errors.New("my inner error")
+	err.Cause = inner
+	require.Equal(t, inner, err.Unwrap())
+}
+
+func TestNilError(t *testing.T) {
+	got := (*PlatformError)(nil).Error()
+	want := `{"code":"ERR_GOLANG_INVALID_LOGIC","message":"nil error","details":""}`
+	require.Equal(t, want, got)
+}
+
+func TestInvalidErrorCode(t *testing.T) {
+	got := (&PlatformError{}).Error()
+	want := `{"code":"ERR_GOLANG_INVALID_LOGIC","message":"empty error code","details":""}`
+	require.Equal(t, want, got)
+}
+
+// Test the output when json.Marshal returns an error, which should not happen.
+// But we want to make sure if it happens the returned JSON is well-formatted.
+func TestJSONMarshalError(t *testing.T) {
+	e := &platformErrJSON{}
+	e.Cause = e
+	errJson, err := json.Marshal(e)
+	require.Nil(t, errJson)
+	require.Error(t, err)
+
+	got := formatInvalidLogicErrJSON("JSON marshal failure", err.Error())
+	want := `{"code":"ERR_GOLANG_INVALID_LOGIC","message":"JSON marshal failure",` +
+		`"details":"json: unsupported value: encountered a cycle via *platerrors.platformErrJSON"}`
+	require.Equal(t, want, got)
+}

--- a/client/src/tun2socks/outline/platerrors/platform_error_test.go
+++ b/client/src/tun2socks/outline/platerrors/platform_error_test.go
@@ -49,7 +49,7 @@ func TestPlatformErrorJSONOutput(t *testing.T) {
 				NewWithDetailsCause("ERR_LVL1", "msg lvl1", ErrorDetails{"details": "here"}, errors.New("go err lvl0"))),
 			want: `{"code":"ERR_LVL2","message":"msg lvl2",` +
 				`"cause":{"code":"ERR_LVL1","message":"msg lvl1","details":{"details":"here"},` +
-				`"cause":{"code":"ERR_GOLANG_ERROR","message":"go err lvl0"}}}`,
+				`"cause":{"code":"ERR_INTERNAL_ERROR","message":"go err lvl0"}}}`,
 		},
 		{
 			name: "Details",
@@ -91,13 +91,13 @@ func TestPlatformErrorWrapsCause(t *testing.T) {
 
 func TestNilError(t *testing.T) {
 	got := (*PlatformError)(nil).Error()
-	want := `{"code":"ERR_INVALID_LOGIC","message":"nil error"}`
+	want := `{"code":"ERR_INTERNAL_ERROR","message":"nil error"}`
 	require.Equal(t, want, got)
 }
 
 func TestInvalidErrorCode(t *testing.T) {
 	got := (&PlatformError{}).Error()
-	want := `{"code":"ERR_INVALID_LOGIC","message":"empty error code"}`
+	want := `{"code":"ERR_INTERNAL_ERROR","message":"empty error code"}`
 	require.Equal(t, want, got)
 }
 
@@ -110,14 +110,14 @@ func TestJSONMarshalError(t *testing.T) {
 	require.Nil(t, errJson)
 	require.Error(t, err)
 
-	got := formatInvalidLogicErrJSON("JSON marshal failure: " + err.Error())
-	want := `{"code":"ERR_INVALID_LOGIC","message":` +
+	got := formatInternalErrorJSON("JSON marshal failure: " + err.Error())
+	want := `{"code":"ERR_INTERNAL_ERROR","message":` +
 		`"JSON marshal failure: json: unsupported value: encountered a cycle via *platerrors.platformErrJSON"}`
 	require.Equal(t, want, got)
 }
 
 func TestEscapeInFormatInvalidLogicErrJSON(t *testing.T) {
-	got := formatInvalidLogicErrJSON("Msg with quote \" and backslash \\")
-	want := `{"code":"ERR_INVALID_LOGIC","message":"Msg with quote  and backslash "}`
+	got := formatInternalErrorJSON("Msg with quote \" and backslash \\")
+	want := `{"code":"ERR_INTERNAL_ERROR","message":"Msg with quote  and backslash "}`
 	require.Equal(t, want, got)
 }

--- a/client/src/tun2socks/outline/shadowsocks/client.go
+++ b/client/src/tun2socks/outline/shadowsocks/client.go
@@ -56,7 +56,7 @@ func NewClientFromJSON(configJSON string) (*Client, error) {
 	var prefixBytes []byte = nil
 	if len(config.Prefix) > 0 {
 		if p, err := utf8.DecodeUTF8CodepointsToRawBytes(config.Prefix); err != nil {
-			return nil, platerrors.NewWithCause(platerrors.IllegalConfigPrefix, "failed to decode prefix string", err)
+			return nil, newConfigErrorWithDetails("prefix is not valid", "prefix", config.Prefix, "string in utf-8", err)
 		} else {
 			prefixBytes = p
 		}
@@ -78,7 +78,8 @@ func newShadowsocksClient(host string, port int, cipherName, password string, pr
 
 	cryptoKey, err := shadowsocks.NewEncryptionKey(cipherName, password)
 	if err != nil {
-		return nil, platerrors.NewWithCause(platerrors.IllegalConfigCipher, "failed to create Shadowsocks cipher", err)
+		return nil, newConfigErrorWithDetails("cipher&password pair is not valid",
+			"cipher|password", cipherName+"|"+password, "valid combination", err)
 	}
 
 	// We disable Keep-Alive as per https://datatracker.ietf.org/doc/html/rfc1122#page-101, which states that it should only be

--- a/client/src/tun2socks/outline/shadowsocks/client.go
+++ b/client/src/tun2socks/outline/shadowsocks/client.go
@@ -28,6 +28,7 @@ import (
 	"github.com/Jigsaw-Code/outline-apps/client/src/tun2socks/outline"
 	"github.com/Jigsaw-Code/outline-apps/client/src/tun2socks/outline/connectivity"
 	"github.com/Jigsaw-Code/outline-apps/client/src/tun2socks/outline/internal/utf8"
+	"github.com/Jigsaw-Code/outline-apps/client/src/tun2socks/outline/platerrors"
 	"github.com/Jigsaw-Code/outline-sdk/transport"
 	"github.com/Jigsaw-Code/outline-sdk/transport/shadowsocks"
 	"github.com/eycorsican/go-tun2socks/common/log"
@@ -41,22 +42,21 @@ type Client outline.Client
 // Deprecated: Please use NewClientFromJSON.
 func NewClient(config *Config) (*Client, error) {
 	if config == nil {
-		return nil, fmt.Errorf("shadowsocks configuration is required")
+		return nil, platerrors.New(platerrors.IllegalArgument, "Shadowsocks config must not be nil")
 	}
 	return newShadowsocksClient(config.Host, config.Port, config.CipherName, config.Password, config.Prefix)
 }
 
-// NewClientFromJSON creates a new Shadowsocks client from a JSON formatted
-// configuration.
+// NewClientFromJSON creates a new Shadowsocks client from a JSON formatted configuration.
 func NewClientFromJSON(configJSON string) (*Client, error) {
 	config, err := parseConfigFromJSON(configJSON)
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse Shadowsocks configuration JSON: %w", err)
+		return nil, platerrors.NewWithCause(platerrors.IllegalJSONString, "failed to parse Shadowsocks config", err)
 	}
 	var prefixBytes []byte = nil
 	if len(config.Prefix) > 0 {
 		if p, err := utf8.DecodeUTF8CodepointsToRawBytes(config.Prefix); err != nil {
-			return nil, fmt.Errorf("failed to parse prefix string: %w", err)
+			return nil, platerrors.NewWithCause(platerrors.IllegalConfigPrefix, "failed to decode prefix string", err)
 		} else {
 			prefixBytes = p
 		}
@@ -66,26 +66,26 @@ func NewClientFromJSON(configJSON string) (*Client, error) {
 
 func newShadowsocksClient(host string, port int, cipherName, password string, prefix []byte) (*Client, error) {
 	if err := validateConfig(host, port, cipherName, password); err != nil {
-		return nil, fmt.Errorf("invalid Shadowsocks configuration: %w", err)
+		return nil, err
 	}
 
 	// TODO: consider using net.LookupIP to get a list of IPs, and add logic for optimal selection.
 	proxyIP, err := net.ResolveIPAddr("ip", host)
 	if err != nil {
-		return nil, fmt.Errorf("failed to resolve proxy address: %w", err)
+		return nil, platerrors.NewWithCause(platerrors.ResolveIPFailed, "failed to resolve ip of the proxy host", err)
 	}
 	proxyAddress := net.JoinHostPort(proxyIP.String(), fmt.Sprint(port))
 
 	cryptoKey, err := shadowsocks.NewEncryptionKey(cipherName, password)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create Shadowsocks cipher: %w", err)
+		return nil, platerrors.NewWithCause(platerrors.IllegalConfigCipher, "failed to create Shadowsocks cipher", err)
 	}
 
 	// We disable Keep-Alive as per https://datatracker.ietf.org/doc/html/rfc1122#page-101, which states that it should only be
 	// enabled in server applications. This prevents the device from unnecessarily waking up to send keep alives.
 	streamDialer, err := shadowsocks.NewStreamDialer(&transport.TCPEndpoint{Address: proxyAddress, Dialer: net.Dialer{KeepAlive: -1}}, cryptoKey)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create StreamDialer: %w", err)
+		return nil, platerrors.NewWithCause(platerrors.SSStreamDialerFailed, "failed to create StreamDialer", err)
 	}
 	if len(prefix) > 0 {
 		log.Debugf("Using salt prefix: %s", string(prefix))
@@ -94,7 +94,7 @@ func newShadowsocksClient(host string, port int, cipherName, password string, pr
 
 	packetListener, err := shadowsocks.NewPacketListener(&transport.UDPEndpoint{Address: proxyAddress}, cryptoKey)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create PacketListener: %w", err)
+		return nil, platerrors.NewWithCause(platerrors.SSPacketListenerFailed, "failed to create PacketListener", err)
 	}
 
 	return &Client{StreamDialer: streamDialer, PacketListener: packetListener}, nil

--- a/client/src/tun2socks/outline/shadowsocks/client.go
+++ b/client/src/tun2socks/outline/shadowsocks/client.go
@@ -27,7 +27,6 @@ import (
 
 	"github.com/Jigsaw-Code/outline-apps/client/src/tun2socks/outline"
 	"github.com/Jigsaw-Code/outline-apps/client/src/tun2socks/outline/connectivity"
-	"github.com/Jigsaw-Code/outline-apps/client/src/tun2socks/outline/internal/utf8"
 	"github.com/Jigsaw-Code/outline-apps/client/src/tun2socks/outline/platerrors"
 	"github.com/Jigsaw-Code/outline-sdk/transport"
 	"github.com/Jigsaw-Code/outline-sdk/transport/shadowsocks"
@@ -53,13 +52,9 @@ func NewClientFromJSON(configJSON string) (*Client, error) {
 	if err != nil {
 		return nil, newIllegalConfigErrorWithDetails("Shadowsocks config must be a valid JSON string", ".", configJSON, "JSON string", err)
 	}
-	var prefixBytes []byte = nil
-	if len(config.Prefix) > 0 {
-		if p, err := utf8.DecodeUTF8CodepointsToRawBytes(config.Prefix); err != nil {
-			return nil, newIllegalConfigErrorWithDetails("prefix is not valid", "prefix", config.Prefix, "string in utf-8", err)
-		} else {
-			prefixBytes = p
-		}
+	prefixBytes, err := ParseConfigPrefixFromString(config.Prefix)
+	if err != nil {
+		return nil, err
 	}
 	return newShadowsocksClient(config.Host, int(config.Port), config.Method, config.Password, prefixBytes)
 }

--- a/client/src/tun2socks/outline/shadowsocks/config.go
+++ b/client/src/tun2socks/outline/shadowsocks/config.go
@@ -60,16 +60,25 @@ func parseConfigFromJSON(in string) (*configJSON, error) {
 // Returns nil if it is valid; or a [platerrors.PlatformError].
 func validateConfig(host string, port int, cipher, password string) error {
 	if len(host) == 0 {
-		return platerrors.New(platerrors.IllegalConfigHost, "host name or IP must not be nil")
+		return newConfigErrorWithDetails("host name or IP is not valid", "host", host, "not nil", nil)
 	}
 	if port <= 0 || port > 65535 {
-		return platerrors.New(platerrors.IllegalConfigPort, "port must be within range [1..65535]")
+		return newConfigErrorWithDetails("port is not valid", "port", port, "within range [1..65535]", nil)
 	}
 	if len(cipher) == 0 {
-		return platerrors.New(platerrors.IllegalConfigCipher, "cipher method must not be nil")
+		return newConfigErrorWithDetails("cipher method is not valid", "cipher", cipher, "not nil", nil)
 	}
 	if len(password) == 0 {
-		return platerrors.New(platerrors.IllegalConfigPassword, "password must not be nil")
+		return newConfigErrorWithDetails("password is not valid", "password", password, "not nil", nil)
 	}
 	return nil
+}
+
+// newConfigErrorWithDetails creates a TypeScript parsable SSIllegalConfig error with detailed information.
+func newConfigErrorWithDetails(msg, field string, got interface{}, expect string, cause error) *platerrors.PlatformError {
+	return platerrors.NewWithDetailsCause(platerrors.SSIllegalConfig, msg, platerrors.ErrorDetails{
+		"field":  field,
+		"got":    got,
+		"expect": expect,
+	}, cause)
 }

--- a/client/src/tun2socks/outline/shadowsocks/config.go
+++ b/client/src/tun2socks/outline/shadowsocks/config.go
@@ -60,25 +60,26 @@ func parseConfigFromJSON(in string) (*configJSON, error) {
 // Returns nil if it is valid; or a [platerrors.PlatformError].
 func validateConfig(host string, port int, cipher, password string) error {
 	if len(host) == 0 {
-		return newConfigErrorWithDetails("host name or IP is not valid", "host", host, "not nil", nil)
+		return newIllegalConfigErrorWithDetails("host name or IP is not valid", "host", host, "not nil", nil)
 	}
 	if port <= 0 || port > 65535 {
-		return newConfigErrorWithDetails("port is not valid", "port", port, "within range [1..65535]", nil)
+		return newIllegalConfigErrorWithDetails("port is not valid", "port", port, "within range [1..65535]", nil)
 	}
 	if len(cipher) == 0 {
-		return newConfigErrorWithDetails("cipher method is not valid", "cipher", cipher, "not nil", nil)
+		return newIllegalConfigErrorWithDetails("cipher method is not valid", "cipher", cipher, "not nil", nil)
 	}
 	if len(password) == 0 {
-		return newConfigErrorWithDetails("password is not valid", "password", password, "not nil", nil)
+		return newIllegalConfigErrorWithDetails("password is not valid", "password", password, "not nil", nil)
 	}
 	return nil
 }
 
-// newConfigErrorWithDetails creates a TypeScript parsable SSIllegalConfig error with detailed information.
-func newConfigErrorWithDetails(msg, field string, got interface{}, expect string, cause error) *platerrors.PlatformError {
-	return platerrors.NewWithDetailsCause(platerrors.SSIllegalConfig, msg, platerrors.ErrorDetails{
-		"field":  field,
-		"got":    got,
-		"expect": expect,
+// newIllegalConfigErrorWithDetails creates a TypeScript parsable SSIllegalConfig error with detailed information.
+func newIllegalConfigErrorWithDetails(msg, field string, got interface{}, expect string, cause error) *platerrors.PlatformError {
+	return platerrors.NewWithDetailsCause(platerrors.IllegalConfig, msg, platerrors.ErrorDetails{
+		"proxy-protocol": "shadowsocks",
+		"field":          field,
+		"got":            got,
+		"expect":         expect,
 	}, cause)
 }

--- a/client/src/tun2socks/outline/shadowsocks/config.go
+++ b/client/src/tun2socks/outline/shadowsocks/config.go
@@ -85,8 +85,10 @@ func validateConfig(host string, port int, cipher, password string) error {
 	return nil
 }
 
-// newIllegalConfigErrorWithDetails creates a TypeScript parsable SSIllegalConfig error with detailed information.
-func newIllegalConfigErrorWithDetails(msg, field string, got interface{}, expect string, cause error) *platerrors.PlatformError {
+// newIllegalConfigErrorWithDetails creates a TypeScript parsable IllegalConfig error with detailed information.
+func newIllegalConfigErrorWithDetails(
+	msg, field string, got interface{}, expect string, cause error,
+) *platerrors.PlatformError {
 	return platerrors.NewWithDetailsCause(platerrors.IllegalConfig, msg, platerrors.ErrorDetails{
 		"proxy-protocol": "shadowsocks",
 		"field":          field,

--- a/client/src/tun2socks/outline/shadowsocks/config.go
+++ b/client/src/tun2socks/outline/shadowsocks/config.go
@@ -16,7 +16,8 @@ package shadowsocks
 
 import (
 	"encoding/json"
-	"fmt"
+
+	"github.com/Jigsaw-Code/outline-apps/client/src/tun2socks/outline/platerrors"
 )
 
 // Config represents a (legacy) shadowsocks server configuration. You can use
@@ -56,19 +57,19 @@ func parseConfigFromJSON(in string) (*configJSON, error) {
 // validateConfig validates whether a Shadowsocks server configuration is valid
 // (it won't do any connectivity tests)
 //
-// Returns nil if it is valid; or an error message.
+// Returns nil if it is valid; or a [platerrors.PlatformError].
 func validateConfig(host string, port int, cipher, password string) error {
 	if len(host) == 0 {
-		return fmt.Errorf("must provide a host name or IP address")
+		return platerrors.New(platerrors.IllegalConfigHost, "host name or IP must not be nil")
 	}
 	if port <= 0 || port > 65535 {
-		return fmt.Errorf("port must be within range [1..65535]")
+		return platerrors.New(platerrors.IllegalConfigPort, "port must be within range [1..65535]")
 	}
 	if len(cipher) == 0 {
-		return fmt.Errorf("must provide an encryption cipher method")
+		return platerrors.New(platerrors.IllegalConfigCipher, "cipher method must not be nil")
 	}
 	if len(password) == 0 {
-		return fmt.Errorf("must provide a password")
+		return platerrors.New(platerrors.IllegalConfigPassword, "password must not be nil")
 	}
 	return nil
 }

--- a/client/src/tun2socks/outline/shadowsocks/config.go
+++ b/client/src/tun2socks/outline/shadowsocks/config.go
@@ -17,6 +17,7 @@ package shadowsocks
 import (
 	"encoding/json"
 
+	"github.com/Jigsaw-Code/outline-apps/client/src/tun2socks/outline/internal/utf8"
 	"github.com/Jigsaw-Code/outline-apps/client/src/tun2socks/outline/platerrors"
 )
 
@@ -31,6 +32,16 @@ type Config struct {
 	Password   string
 	CipherName string
 	Prefix     []byte
+}
+
+func ParseConfigPrefixFromString(raw string) (p []byte, err error) {
+	if len(raw) == 0 {
+		return nil, nil
+	}
+	if p, err = utf8.DecodeUTF8CodepointsToRawBytes(raw); err != nil {
+		return nil, newIllegalConfigErrorWithDetails("prefix is not valid", "prefix", raw, "string in utf-8", err)
+	}
+	return
 }
 
 // An internal data structure to be used by JSON deserialization.

--- a/client/src/www/app/app.ts
+++ b/client/src/www/app/app.ts
@@ -17,6 +17,7 @@ import {OperationTimedOut} from '@outline/infrastructure/timeout_promise';
 
 import {Clipboard} from './clipboard';
 import {EnvironmentVariables} from './environment';
+import {localizeErrorCode} from './error_code_localizer';
 import {OutlineServerRepository} from './outline_server_repository';
 import {Settings, SettingsKey} from './settings';
 import {Updater} from './updater';
@@ -24,9 +25,10 @@ import {UrlInterceptor} from './url_interceptor';
 import {VpnInstaller} from './vpn_installer';
 import * as errors from '../model/errors';
 import * as events from '../model/events';
+import {PlatformError} from '../model/platform_error';
 import {Server} from '../model/server';
 import {OutlineErrorReporter} from '../shared/error_reporter';
-import {ServerListItem, ServerConnectionState} from '../views/servers_view';
+import {ServerConnectionState, ServerListItem} from '../views/servers_view';
 import {SERVER_CONNECTION_INDICATOR_DURATION_MS} from '../views/servers_view/server_connection_indicator';
 
 enum OUTLINE_ACCESS_KEY_SCHEME {
@@ -221,6 +223,10 @@ export class App {
       buttonHandler = () => {
         this.showErrorDetailsDialog(error.details);
       };
+    } else if (error instanceof PlatformError) {
+      toastMessage = localizeErrorCode(error.code, this.localize);
+      buttonMessage = this.localize('error-details');
+      buttonHandler = () => this.showErrorDetailsDialog(error.toString());
     } else {
       const hasErrorDetails = Boolean(error.message || error.cause);
       toastMessage = this.localize('error-unexpected');

--- a/client/src/www/app/app.ts
+++ b/client/src/www/app/app.ts
@@ -17,7 +17,7 @@ import {OperationTimedOut} from '@outline/infrastructure/timeout_promise';
 
 import {Clipboard} from './clipboard';
 import {EnvironmentVariables} from './environment';
-import {localizeErrorCode} from './error_code_localizer';
+import {localizeErrorCode} from './error_localizer';
 import {OutlineServerRepository} from './outline_server_repository';
 import {Settings, SettingsKey} from './settings';
 import {Updater} from './updater';

--- a/client/src/www/app/app.ts
+++ b/client/src/www/app/app.ts
@@ -411,7 +411,7 @@ export class App {
       this.maybeShowAutoConnectDialog();
     } catch (e) {
       this.updateServerListItem(serverId, {connectionState: ServerConnectionState.DISCONNECTED});
-      console.error(`could not connect to server ${serverId}: ${e.name}`);
+      console.error(`could not connect to server ${serverId}: ${e}`);
       if (e instanceof errors.SystemConfigurationException) {
         if (await this.showConfirmationDialog(this.localize('outline-services-installation-confirmation'))) {
           await this.installVpnService();

--- a/client/src/www/app/electron_outline_tunnel.ts
+++ b/client/src/www/app/electron_outline_tunnel.ts
@@ -12,9 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {Tunnel, TunnelStatus, ShadowsocksSessionConfig} from './tunnel';
-import * as errors from '../model/errors';
-
+import {PlatformError} from '../model/platform_error';
+import {ShadowsocksSessionConfig, Tunnel, TunnelStatus} from './tunnel';
 
 export class ElectronOutlineTunnel implements Tunnel {
   private statusChangeListener: ((status: TunnelStatus) => void) | null = null;
@@ -41,9 +40,9 @@ export class ElectronOutlineTunnel implements Tunnel {
       this.handleStatusChange(TunnelStatus.DISCONNECTED);
     });
 
-    const err = await window.electron.methodChannel.invoke('start-proxying', {config, id: this.id});
-    if (err != errors.ErrorCode.NO_ERROR) {
-      throw new errors.OutlinePluginError(err);
+    const errJSON: string | null = await window.electron.methodChannel.invoke('start-proxying', {config, id: this.id});
+    if (errJSON) {
+      throw PlatformError.parseJSON(errJSON);
     }
     this.running = true;
   }

--- a/client/src/www/app/electron_outline_tunnel.ts
+++ b/client/src/www/app/electron_outline_tunnel.ts
@@ -40,11 +40,12 @@ export class ElectronOutlineTunnel implements Tunnel {
       this.handleStatusChange(TunnelStatus.DISCONNECTED);
     });
 
-    const errJSON: string | null = await window.electron.methodChannel.invoke('start-proxying', {config, id: this.id});
-    if (errJSON) {
-      throw PlatformError.parseJSON(errJSON);
+    try {
+      await window.electron.methodChannel.invoke('start-proxying', {config, id: this.id});
+      this.running = true;
+    } catch (e) {
+      throw PlatformError.parseFrom(e);
     }
-    this.running = true;
   }
 
   async stop() {

--- a/client/src/www/app/electron_outline_tunnel.ts
+++ b/client/src/www/app/electron_outline_tunnel.ts
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {PlatformError} from '../model/platform_error';
 import {ShadowsocksSessionConfig, Tunnel, TunnelStatus} from './tunnel';
+import {PlatformError} from '../model/platform_error';
 
 export class ElectronOutlineTunnel implements Tunnel {
   private statusChangeListener: ((status: TunnelStatus) => void) | null = null;

--- a/client/src/www/app/error_code_localizer.ts
+++ b/client/src/www/app/error_code_localizer.ts
@@ -12,13 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { Localizer } from '@outline/infrastructure/i18n';
+import {Localizer} from '@outline/infrastructure/i18n';
 
-import { ErrorCode, ServerUnreachable } from '../model/platform_error';
+import {ErrorCode, ServerUnreachable} from '../model/platform_error';
 
-const errCodeMapping = new Map<string, string>([
-  [ServerUnreachable, 'outline-plugin-error-server-unreachable'],
-]);
+const errCodeMapping = new Map<string, string>([[ServerUnreachable, 'outline-plugin-error-server-unreachable']]);
 
 export function localizeErrorCode(code: ErrorCode, localize: Localizer): string {
   return localize(errCodeMapping.get(code) || 'error-unexpected');

--- a/client/src/www/app/error_code_localizer.ts
+++ b/client/src/www/app/error_code_localizer.ts
@@ -1,0 +1,25 @@
+// Copyright 2024 The Outline Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { Localizer } from '@outline/infrastructure/i18n';
+
+import { ErrorCode, ServerUnreachable } from '../model/platform_error';
+
+const errCodeMapping = new Map<string, string>([
+  [ServerUnreachable, 'outline-plugin-error-server-unreachable'],
+]);
+
+export function localizeErrorCode(code: ErrorCode, localize: Localizer): string {
+  return localize(errCodeMapping.get(code) || 'error-unexpected');
+}

--- a/client/src/www/app/error_localizer.ts
+++ b/client/src/www/app/error_localizer.ts
@@ -14,9 +14,13 @@
 
 import {Localizer} from '@outline/infrastructure/i18n';
 
-import {ErrorCode, ServerUnreachable} from '../model/platform_error';
+import {ErrorCode, FetchConfigFailure, IllegalConfig, ProxyServerUnreachable} from '../model/platform_error';
 
-const errCodeMapping = new Map<string, string>([[ServerUnreachable, 'outline-plugin-error-server-unreachable']]);
+const errCodeMapping = new Map<string, string>([
+  [ProxyServerUnreachable, 'outline-plugin-error-server-unreachable'],
+  [IllegalConfig, 'error-connection-configuration'],
+  [FetchConfigFailure, 'error-connection-configuration-fetch'],
+]);
 
 export function localizeErrorCode(code: ErrorCode, localize: Localizer): string {
   return localize(errCodeMapping.get(code) || 'error-unexpected');

--- a/client/src/www/app/error_localizer.ts
+++ b/client/src/www/app/error_localizer.ts
@@ -14,12 +14,12 @@
 
 import {Localizer} from '@outline/infrastructure/i18n';
 
-import {ErrorCode, FetchConfigFailure, IllegalConfig, ProxyServerUnreachable} from '../model/platform_error';
+import {ErrorCode, FETCH_CONFIG_FAILED, ILLEGAL_CONFIG, PROXY_SERVER_UNREACHABLE} from '../model/platform_error';
 
-const errCodeMapping = new Map<string, string>([
-  [ProxyServerUnreachable, 'outline-plugin-error-server-unreachable'],
-  [IllegalConfig, 'error-connection-configuration'],
-  [FetchConfigFailure, 'error-connection-configuration-fetch'],
+const errCodeMapping = new Map<ErrorCode, string>([
+  [PROXY_SERVER_UNREACHABLE, 'outline-plugin-error-server-unreachable'],
+  [ILLEGAL_CONFIG, 'error-connection-configuration'],
+  [FETCH_CONFIG_FAILED, 'error-connection-configuration-fetch'],
 ]);
 
 export function localizeErrorCode(code: ErrorCode, localize: Localizer): string {

--- a/client/src/www/app/outline_server_repository/server.ts
+++ b/client/src/www/app/outline_server_repository/server.ts
@@ -19,7 +19,6 @@ import {PlatformError} from '../../model/platform_error';
 import {Server, ServerType} from '../../model/server';
 import {Tunnel, TunnelStatus, ShadowsocksSessionConfig} from '../tunnel';
 
-
 // PLEASE DON'T use this class outside of this `outline_server_repository` folder!
 
 export class OutlineServer implements Server {

--- a/client/src/www/app/outline_server_repository/server.ts
+++ b/client/src/www/app/outline_server_repository/server.ts
@@ -15,6 +15,7 @@
 import {fetchShadowsocksSessionConfig, staticKeyToShadowsocksSessionConfig} from './access_key_serialization';
 import * as errors from '../../model/errors';
 import * as events from '../../model/events';
+import {PlatformError} from '../../model/platform_error';
 import {Server, ServerType} from '../../model/server';
 import {Tunnel, TunnelStatus, ShadowsocksSessionConfig} from '../tunnel';
 
@@ -101,6 +102,11 @@ export class OutlineServer implements Server {
     try {
       await this.tunnel.start(this.sessionConfig);
     } catch (cause) {
+      // TODO(junyi): Remove the catch above once all platforms are migrated to PlatformError
+      if (cause instanceof PlatformError) {
+        throw cause;
+      }
+
       // e originates in "native" code: either Cordova or Electron's main process.
       // Because of this, we cannot assume "instanceof OutlinePluginError" will work.
       if (cause.errorCode) {

--- a/client/src/www/model/errors.ts
+++ b/client/src/www/model/errors.ts
@@ -87,6 +87,8 @@ export class OutlinePluginError extends CustomError {
 // Bifurcates into two subclasses:
 //  - "expected" errors originating in native code, e.g. incorrect password
 //  - "unexpected" errors originating in native code, e.g. unhandled routing table
+//
+// NativeError is being replaced by PlatformError. Please use PlatformError for new code.
 export class NativeError extends CustomError {}
 export class RegularNativeError extends NativeError {}
 export class RedFlagNativeError extends NativeError {}

--- a/client/src/www/model/platform_error.ts
+++ b/client/src/www/model/platform_error.ts
@@ -1,0 +1,150 @@
+// Copyright 2024 The Outline Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { CustomError } from '@outline/infrastructure/custom_error';
+
+//////
+// This file defines types and constants corresponding to the backend Go's `platerrors` package.
+// It will be used to receive native errors from Go, eventually replacing the older NativeError type.
+//////
+
+/**
+ * Creates a new {@link PlatformError} of {@link InvalidLogic} representing that we failed to parse
+ * PlatformError JSON string, typically this is a development error.
+ * @param message The message that will be included in the result.
+ * @param rawJSONObj The invalid JSON object that will be included as the details of the result.
+ * @returns {PlatformError} A non-null instance of PlatformError.
+ */
+function newInvalidJSONPlatformError(message: string, rawJSONObj: any): PlatformError {
+  return new PlatformError(InvalidLogic, message, { details: { 'json': rawJSONObj } });
+}
+
+/**
+ * Recursively validates and parses a {@link rawObj} into a {@link PlatformError}.
+ *
+ * If {@link rawObj} is invalid, a {@link newInvalidJSONPlatformError} will be returned.
+ * Otherwise, we will return the parsed {@link PlatformError}.
+ * @param {object} rawObj Any object that is returned by JSON.parse.
+ * @returns {PlatformError} A non-null instance of PlatformError.
+ */
+function convertRawErrorObjectToPlatformError(rawObj: object): PlatformError {
+  if (!rawObj) {
+    return newInvalidJSONPlatformError("error JSON is falsy", rawObj);
+  }
+
+  if (!('code' in rawObj) || typeof rawObj.code !== 'string') {
+    return newInvalidJSONPlatformError('`code` is not string in error JSON', rawObj);
+  }
+  const code = rawObj.code.trim();
+  if (!code) {
+    return newInvalidJSONPlatformError('`code` is empty in error JSON', rawObj);
+  }
+
+  if (!('message' in rawObj) || typeof rawObj.message !== 'string') {
+    return newInvalidJSONPlatformError('`message` is not string in error JSON', rawObj);
+  }
+
+  let options: { details?: object, cause?: Error } = null;
+  if ('details' in rawObj || 'cause' in rawObj) {
+    options = {};
+    if ('details' in rawObj && typeof rawObj.details === 'object' && rawObj.details) {
+      options.details = rawObj.details;
+    }
+    if ('cause' in rawObj && typeof rawObj.cause === 'object' && rawObj.cause) {
+      options.cause = convertRawErrorObjectToPlatformError(rawObj.cause);
+    }
+  }
+
+  return new PlatformError(code, rawObj.message, options);
+}
+
+/**
+ * PlatformError is used to communicate error details from Go to TypeScript.
+ */
+export class PlatformError extends CustomError {
+  public readonly details: object = null;
+
+  /**
+   * Constructs a new PlatformError instance with the specified parameters.
+   * @param {ErrorCode} code An ErrorCode representing the category of this error.
+   * @param {string} message A user-readable string of this error.
+   * @param options An object containing the optional details and cause. 
+   */
+  constructor(public readonly code: ErrorCode,
+    message: string,
+    options?: {
+      details?: object,
+      cause?: Error,
+    }) {
+    super(message, options);
+    this.details = options?.details;
+  }
+
+  /**
+   * Parses a JSON string into a {@link PlatformError}.
+   *
+   * If {@link rawJSON} is invalid, it returns a PlatformError of {@link InvalidLogic} with the
+   * original JSON in its details.
+   * @param {string} rawJSON The JSON string to parse.
+   * @returns {PlatformError} A non-null PlatformError object.
+   */
+  static parseJSON(rawJSON: string): PlatformError {
+    let rawObj: unknown;
+    try {
+      rawObj = JSON.parse(rawJSON);
+    } catch {
+      return newInvalidJSONPlatformError("invalid error JSON string", rawJSON);
+    }
+    if (typeof rawObj !== 'object') {
+      return newInvalidJSONPlatformError("error JSON is not an object", rawObj);
+    }
+    return convertRawErrorObjectToPlatformError(rawObj);
+  }
+
+  /**
+   * Returns a user readable string of this error with all details and causes.
+   * @returns {string} A user friendly string representing this error.
+   */
+  public toString(): string {
+    let result = this.code + "\n" + this.message;
+    if (this.details) {
+      result += "\nDetails: ";
+      try {
+        result += JSON.stringify(this.details, null, 2);
+      } catch {
+        result += "<Unable To Show>";
+      }
+    }
+    if (this.cause) {
+      const subStr = this.cause.toString();
+      // Indent and append
+      result += "\nCaused by:\n" + subStr.replace(/^/gm, '  ');
+    }
+    return result;
+  }
+}
+
+//////
+// Error Code Definitions
+// They should be identical to the ones defined in Go's `platerrors` package.
+//////
+
+/**
+ * ErrorCode can be used to identify the specific type of a {@link PlatformError}.
+ * You can reliably use the constant values to check for specific errors.
+ */
+export type ErrorCode = string;
+
+export const InvalidLogic: ErrorCode = "ERR_INVALID_LOGIC";
+export const ServerUnreachable: ErrorCode = "ERR_SERVER_UNREACHABLE";

--- a/client/src/www/model/platform_error.ts
+++ b/client/src/www/model/platform_error.ts
@@ -27,7 +27,7 @@ import {CustomError} from '@outline/infrastructure/custom_error';
  * @returns {PlatformError} A non-null instance of PlatformError.
  */
 function newInvalidJSONPlatformError(message: string, rawJSONObj: object | string): PlatformError {
-  return new PlatformError(InvalidLogic, message, {details: {json: rawJSONObj}});
+  return new PlatformError(InternalError, message, {details: {json: rawJSONObj}});
 }
 
 /**
@@ -148,9 +148,9 @@ export class PlatformError extends CustomError {
  */
 export type ErrorCode = string;
 
-export const InvalidLogic: ErrorCode = 'ERR_INVALID_LOGIC';
+export const InternalError: ErrorCode = 'ERR_INTERNAL_ERROR';
 
-export const FetchConfigFailure: ErrorCode = 'ERR_FETCH_REMOTE_CONFIG_FAILURE';
+export const FetchConfigFailed: ErrorCode = 'ERR_FETCH_CONFIG_FAILURE';
 export const IllegalConfig: ErrorCode = 'ERR_ILLEGAL_CONFIG';
 
 export const ProxyServerUnreachable: ErrorCode = 'ERR_PROXY_SERVER_UNREACHABLE';

--- a/client/src/www/model/platform_error.ts
+++ b/client/src/www/model/platform_error.ts
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { CustomError } from '@outline/infrastructure/custom_error';
+import {CustomError} from '@outline/infrastructure/custom_error';
 
 //////
 // This file defines types and constants corresponding to the backend Go's `platerrors` package.
@@ -27,7 +27,7 @@ import { CustomError } from '@outline/infrastructure/custom_error';
  * @returns {PlatformError} A non-null instance of PlatformError.
  */
 function newInvalidJSONPlatformError(message: string, rawJSONObj: any): PlatformError {
-  return new PlatformError(InvalidLogic, message, { details: { 'json': rawJSONObj } });
+  return new PlatformError(InvalidLogic, message, {details: {json: rawJSONObj}});
 }
 
 /**
@@ -40,7 +40,7 @@ function newInvalidJSONPlatformError(message: string, rawJSONObj: any): Platform
  */
 function convertRawErrorObjectToPlatformError(rawObj: object): PlatformError {
   if (!rawObj) {
-    return newInvalidJSONPlatformError("error JSON is falsy", rawObj);
+    return newInvalidJSONPlatformError('error JSON is falsy', rawObj);
   }
 
   if (!('code' in rawObj) || typeof rawObj.code !== 'string') {
@@ -55,7 +55,7 @@ function convertRawErrorObjectToPlatformError(rawObj: object): PlatformError {
     return newInvalidJSONPlatformError('`message` is not string in error JSON', rawObj);
   }
 
-  let options: { details?: object, cause?: Error } = null;
+  let options: {details?: object; cause?: Error} = null;
   if ('details' in rawObj || 'cause' in rawObj) {
     options = {};
     if ('details' in rawObj && typeof rawObj.details === 'object' && rawObj.details) {
@@ -79,14 +79,16 @@ export class PlatformError extends CustomError {
    * Constructs a new PlatformError instance with the specified parameters.
    * @param {ErrorCode} code An ErrorCode representing the category of this error.
    * @param {string} message A user-readable string of this error.
-   * @param options An object containing the optional details and cause. 
+   * @param options An object containing the optional details and cause.
    */
-  constructor(public readonly code: ErrorCode,
+  constructor(
+    public readonly code: ErrorCode,
     message: string,
     options?: {
-      details?: object,
-      cause?: Error,
-    }) {
+      details?: object;
+      cause?: Error;
+    }
+  ) {
     super(message, options);
     this.details = options?.details;
   }
@@ -104,10 +106,10 @@ export class PlatformError extends CustomError {
     try {
       rawObj = JSON.parse(rawJSON);
     } catch {
-      return newInvalidJSONPlatformError("invalid error JSON string", rawJSON);
+      return newInvalidJSONPlatformError('invalid error JSON string', rawJSON);
     }
     if (typeof rawObj !== 'object') {
-      return newInvalidJSONPlatformError("error JSON is not an object", rawObj);
+      return newInvalidJSONPlatformError('error JSON is not an object', rawObj);
     }
     return convertRawErrorObjectToPlatformError(rawObj);
   }
@@ -117,19 +119,19 @@ export class PlatformError extends CustomError {
    * @returns {string} A user friendly string representing this error.
    */
   public toString(): string {
-    let result = this.code + "\n" + this.message;
+    let result = this.code + '\n' + this.message;
     if (this.details) {
-      result += "\nDetails: ";
+      result += '\nDetails: ';
       try {
         result += JSON.stringify(this.details, null, 2);
       } catch {
-        result += "<Unable To Show>";
+        result += '<Unable To Show>';
       }
     }
     if (this.cause) {
       const subStr = this.cause.toString();
       // Indent and append
-      result += "\nCaused by:\n" + subStr.replace(/^/gm, '  ');
+      result += '\nCaused by:\n' + subStr.replace(/^/gm, '  ');
     }
     return result;
   }
@@ -146,5 +148,5 @@ export class PlatformError extends CustomError {
  */
 export type ErrorCode = string;
 
-export const InvalidLogic: ErrorCode = "ERR_INVALID_LOGIC";
-export const ServerUnreachable: ErrorCode = "ERR_SERVER_UNREACHABLE";
+export const InvalidLogic: ErrorCode = 'ERR_INVALID_LOGIC';
+export const ServerUnreachable: ErrorCode = 'ERR_SERVER_UNREACHABLE';

--- a/client/src/www/model/platform_error.ts
+++ b/client/src/www/model/platform_error.ts
@@ -26,7 +26,7 @@ import {CustomError} from '@outline/infrastructure/custom_error';
  * @param rawJSONObj The invalid JSON object that will be included as the details of the result.
  * @returns {PlatformError} A non-null instance of PlatformError.
  */
-function newInvalidJSONPlatformError(message: string, rawJSONObj: any): PlatformError {
+function newInvalidJSONPlatformError(message: string, rawJSONObj: object | string): PlatformError {
   return new PlatformError(InvalidLogic, message, {details: {json: rawJSONObj}});
 }
 
@@ -109,7 +109,7 @@ export class PlatformError extends CustomError {
       return newInvalidJSONPlatformError('invalid error JSON string', rawJSON);
     }
     if (typeof rawObj !== 'object') {
-      return newInvalidJSONPlatformError('error JSON is not an object', rawObj);
+      return newInvalidJSONPlatformError('error JSON is not an object', rawJSON);
     }
     return convertRawErrorObjectToPlatformError(rawObj);
   }

--- a/client/src/www/model/platform_error.ts
+++ b/client/src/www/model/platform_error.ts
@@ -14,10 +14,11 @@
 
 import {CustomError} from '@outline/infrastructure/custom_error';
 
-//////
-// This file defines types and constants corresponding to the backend Go's `platerrors` package.
-// It will be used to receive native errors from Go, eventually replacing the older NativeError type.
-//////
+/**
+ * @fileoverview This file defines types and constants corresponding to the backend Go's
+ * `platerrors` package. It will be used to receive native errors from Go, eventually replacing
+ * the older NativeError type.
+ */
 
 /**
  * Creates a new {@link PlatformError} instance with the error code set to {@link INTERNAL_ERROR}.
@@ -56,7 +57,7 @@ function convertRawErrorObjectToPlatformError(rawObj: object): PlatformError {
     throw new Error('message is invalid');
   }
 
-  let options: {details?: ErrorDetails; cause?: Error} = {};
+  const options: {details?: ErrorDetails; cause?: Error} = {};
   if ('details' in rawObj) {
     if (typeof rawObj.details !== 'object') {
       throw new Error('details is invalid');

--- a/client/src/www/model/platform_error.ts
+++ b/client/src/www/model/platform_error.ts
@@ -149,4 +149,8 @@ export class PlatformError extends CustomError {
 export type ErrorCode = string;
 
 export const InvalidLogic: ErrorCode = 'ERR_INVALID_LOGIC';
-export const ServerUnreachable: ErrorCode = 'ERR_SERVER_UNREACHABLE';
+
+export const FetchConfigFailure: ErrorCode = 'ERR_FETCH_REMOTE_CONFIG_FAILURE';
+export const IllegalConfig: ErrorCode = 'ERR_ILLEGAL_CONFIG';
+
+export const ProxyServerUnreachable: ErrorCode = 'ERR_PROXY_SERVER_UNREACHABLE';

--- a/infrastructure/timeout_promise.ts
+++ b/infrastructure/timeout_promise.ts
@@ -16,7 +16,7 @@ import {CustomError} from './custom_error';
 
 export class OperationTimedOut extends CustomError {
   constructor(readonly timeoutMs: number, public readonly operationName: string) {
-    super();
+    super(`${operationName} timed out after ${timeoutMs} ms`);
   }
 }
 


### PR DESCRIPTION
Added detailed error propagation from Golang to TypeScript for the desktop Outline Client (Windows & Linux).

### New Error Details

**Empty hostname**
<img width="359" alt="image" src="https://github.com/Jigsaw-Code/outline-apps/assets/93548144/f472e696-f3af-4c63-af17-f7e84cc4262f">

**Port out-of-range**
<img width="357" alt="image" src="https://github.com/Jigsaw-Code/outline-apps/assets/93548144/00a85b1c-9c7e-440c-ab4e-88331b79d2a4">



### Current Version (v1.13.1)

**Empty hostname**
<img width="361" alt="image" src="https://github.com/Jigsaw-Code/outline-apps/assets/93548144/cb48c376-d0a5-49aa-986c-c294db6cc5a1">

**Port out-of-range**
<img width="476" alt="image" src="https://github.com/Jigsaw-Code/outline-apps/assets/93548144/6b942e75-903a-424d-8de3-ce667704d599">

