### PR TITLE
ci(manager/mac): use `macos-13` as the CI runner

### DIFF
--- a/.github/workflows/build_and_test_debug_manager.yml
+++ b/.github/workflows/build_and_test_debug_manager.yml
@@ -101,8 +101,5 @@ jobs:
       - name: Install NPM Dependencies
         run: npm ci
 
-      - name: Set XCode Version
-        run: sudo xcode-select -switch /Applications/Xcode_13.2.app
-
       - name: Build MacOS Manager
         run: npm run action server_manager/electron_app/build macos

--- a/.github/workflows/build_and_test_debug_manager.yml
+++ b/.github/workflows/build_and_test_debug_manager.yml
@@ -83,7 +83,7 @@ jobs:
 
   mac_debug_build:
     name: MacOS Debug Build
-    runs-on: macos-11
+    runs-on: macos-13
     needs: web_test
     env:
       SENTRY_DSN: debug


### PR DESCRIPTION
From the [official "About GitHub-hosted runners" document](https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories):

> The macos-11 label has been deprecated and will no longer be available after 28 June 2024.

I replaced it with `macos-13` to align with the [Client runner](https://github.com/Jigsaw-Code/outline-apps/blob/af91355e9e7fc9a20af3cd0aced9593129b050ad/.github/workflows/build_and_test_debug_client.yml#L121), and removed the `xcode-select` command since [XCode 13 is not supported by GitHub actions](https://github.com/actions/runner-images/blob/main/images/macos/macos-13-Readme.md#xcode) any more.

This unblocks #2044 .