### PR TITLE
refactor(client/cordova/android): remove dead reachability test code

### DIFF
--- a/client/src/cordova/android/OutlineAndroidLib/outline/src/main/aidl/org/outline/IVpnTunnelService.aidl
+++ b/client/src/cordova/android/OutlineAndroidLib/outline/src/main/aidl/org/outline/IVpnTunnelService.aidl
@@ -54,14 +54,6 @@ interface IVpnTunnelService {
   boolean isTunnelActive(String tunnelId);
 
   /**
-   * Determines whether a server is reachable via TCP.
-   *
-   * @param host IP or hostname string.
-   * @return port TCP port number.
-   */
-  boolean isServerReachable(String host, int port);
-
-  /**
    * Initializes the error reporting framework on the VPN service process.
    *
    * @param apiKey Sentry API key.

--- a/client/src/cordova/android/OutlineAndroidLib/outline/src/main/java/org/outline/vpn/VpnTunnelService.java
+++ b/client/src/cordova/android/OutlineAndroidLib/outline/src/main/java/org/outline/vpn/VpnTunnelService.java
@@ -126,11 +126,6 @@ public class VpnTunnelService extends VpnService {
     }
 
     @Override
-    public boolean isServerReachable(String host, int port) {
-      return VpnTunnelService.this.isServerReachable(host, port);
-    }
-
-    @Override
     public void initErrorReporting(String apiKey) {
       VpnTunnelService.this.initErrorReporting(apiKey);
     }
@@ -337,15 +332,6 @@ public class VpnTunnelService extends VpnService {
       return false;
     }
     return tunnelConfig.id.equals(tunnelId);
-  }
-
-  private boolean isServerReachable(final String host, final int port) {
-    try {
-      Shadowsocks.checkServerReachable(host, port);
-    } catch (Exception e) {
-      return false;
-    }
-    return true;
   }
 
   /* Helper method to tear down an active tunnel. */

--- a/client/src/cordova/plugin/android/java/org/outline/OutlinePlugin.java
+++ b/client/src/cordova/plugin/android/java/org/outline/OutlinePlugin.java
@@ -54,7 +54,6 @@ public class OutlinePlugin extends CordovaPlugin {
     STOP("stop"),
     ON_STATUS_CHANGE("onStatusChange"),
     IS_RUNNING("isRunning"),
-    IS_REACHABLE("isServerReachable"),
     INIT_ERROR_REPORTING("initializeErrorReporting"),
     REPORT_EVENTS("reportEvents"),
     QUIT("quitApplication");
@@ -205,10 +204,6 @@ public class OutlinePlugin extends CordovaPlugin {
           callback.sendPluginResult(new PluginResult(PluginResult.Status.OK, isActive));
 
           // Static actions
-        } else if (Action.IS_REACHABLE.is(action)) {
-          boolean isReachable =
-              this.vpnTunnelService.isServerReachable(args.getString(0), args.getInt(1));
-          callback.sendPluginResult(new PluginResult(PluginResult.Status.OK, isReachable));
         } else if (Action.INIT_ERROR_REPORTING.is(action)) {
           errorReportingApiKey = args.getString(0);
           // Treat failures to initialize error reporting as unexpected by propagating exceptions.

--- a/client/src/tun2socks/outline/shadowsocks/client.go
+++ b/client/src/tun2socks/outline/shadowsocks/client.go
@@ -22,7 +22,6 @@ package shadowsocks
 import (
 	"fmt"
 	"net"
-	"strconv"
 	"time"
 
 	"github.com/Jigsaw-Code/outline-apps/client/src/tun2socks/outline"
@@ -124,15 +123,4 @@ const reachabilityTimeout = 10 * time.Second
 func CheckConnectivity(client *Client) (int, error) {
 	errCode, err := connectivity.CheckConnectivity((*outline.Client)(client))
 	return errCode.Number(), err
-}
-
-// CheckServerReachable determines whether the server at `host:port` is reachable over TCP.
-// Returns an error if the server is unreachable.
-func CheckServerReachable(host string, port int) error {
-	conn, err := net.DialTimeout("tcp", net.JoinHostPort(host, strconv.Itoa(port)), reachabilityTimeout)
-	if err != nil {
-		return err
-	}
-	conn.Close()
-	return nil
 }


### PR DESCRIPTION
The logic has already been removed in #1663 , this PR cleans up the dead code for Android.