### PR TITLE
build: add missing dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@types/node-fetch": "^2.6.7",
         "@typescript-eslint/eslint-plugin": "^7.7.0",
         "@typescript-eslint/parser": "^7.7.0",
+        "chalk": "^5.3.0",
         "electron-builder": "^24.13.3",
         "eslint-plugin-import": "^2.29.1",
         "node-fetch": "^2.6.7"

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "@types/node-fetch": "^2.6.7",
     "@typescript-eslint/eslint-plugin": "^7.7.0",
     "@typescript-eslint/parser": "^7.7.0",
+    "chalk": "^5.3.0",
     "electron-builder": "^24.13.3",
     "eslint-plugin-import": "^2.29.1",
     "node-fetch": "^2.6.7"


### PR DESCRIPTION
Chalk is used by src/build. It needs to be in the root package.json.