### PR TITLE
Add app version to http header of dynamic access link fetch

### DIFF
--- a/client/src/www/app/outline_server_repository/access_key_serialization.ts
+++ b/client/src/www/app/outline_server_repository/access_key_serialization.ts
@@ -71,7 +71,7 @@ function parseShadowsocksSessionConfigJson(responseBody: string): ShadowsocksSes
 export async function fetchShadowsocksSessionConfig(configLocation: URL): Promise<ShadowsocksSessionConfig> {
   let response;
   try {
-    response = await fetch(configLocation, {cache: 'no-store', redirect: 'follow'});
+    response = await fetch(configLocation, {cache: 'no-store', redirect: 'follow', headers: {'Outline-Version': env.APP_VERSION}});
   } catch (cause) {
     throw new errors.SessionConfigFetchFailed('Failed to fetch VPN information from dynamic access key.', {cause});
   }


### PR DESCRIPTION
`env` is undefined, I wasn't sure what's the best way to import it in this function.

This change has the following impacts:
- Dynamic access link web service can now force client to update Outline if version is not supported
- Makes it future proof if one day an Outline version is not backward compatible
- Prevents detection by DPI if client using an old/bad Outline version


My test:
I put 50 clients with versions from `1.10.0` to `1.13.1` on a server and after a day it got detected and returned `ServerUnreachable` error.

Then I put 50 clients which I was sure they're using version 1.13 and 1.13.1 on windows and it's still going strong with no detection, it even has UDP enabled.

issue #2061 