### PR TITLE
fix(client/electron): `/` are incorrectly removed in `ssconf://` links

### DIFF
--- a/client/electron/index.ts
+++ b/client/electron/index.ts
@@ -247,7 +247,7 @@ function interceptShadowsocksLink(argv: string[]) {
         if (mainWindow) {
           // The system adds a trailing slash to the intercepted URL (before the fragment).
           // Remove it before sending to the UI.
-          url = `${protocol}${url.substr(protocol.length).replace(/\//g, '')}`;
+          url = `${protocol}${url.substring(protocol.length).replace(/\/$/g, '')}`;
           // TODO: refactor channel name and namespace to a constant
           mainWindow.webContents.send('outline-ipc-add-server', url);
         } else {


### PR DESCRIPTION
This is due to a bug in removing trailing slash that removes all of the slashes of the URL.

For example:

`ssconf://cool.url.com/a/b/c` would become `ssconf://cool.url.comabc` which effectively breaks the dynamic server config URL.

This issue needs to be fixed since it broke the functionality of ssconf:// links entered from browser.

Changed `substr` to `substring` since `substr` was deprecated.