### PR TITLE
refactor(client): preliminary wiring of service name

### DIFF
--- a/client/electron/index.ts
+++ b/client/electron/index.ts
@@ -459,7 +459,7 @@ function main() {
   // TODO: refactor channel name and namespace to a constant
   ipcMain.handle(
     'outline-ipc-start-proxying',
-    async (_, args: {config: ShadowsocksSessionConfig; id: string}): Promise<void> => {
+    async (_, args: {id: string, name: string, config: ShadowsocksSessionConfig}): Promise<void> => {
       // TODO: Rather than first disconnecting, implement a more efficient switchover (as well as
       //       being faster, this would help prevent traffic leaks - the Cordova clients already do
       //       this).
@@ -469,7 +469,7 @@ function main() {
         await currentTunnel.onceDisconnected;
       }
 
-      console.log(`connecting to ${args.id}...`);
+      console.log(`connecting to ${args.name} (${args.id})...`);
 
       try {
         // We must convert the host from a potential "hostname" to an "IP" address
@@ -479,7 +479,7 @@ function main() {
         args.config.host = await lookupIp(args.config.host || '');
 
         await startVpn(args.config, args.id);
-        console.log(`connected to ${args.id}`);
+        console.log(`connected to ${args.name} (${args.id})`);
         await setupAutoLaunch(args);
         // Auto-connect requires IPs; the hostname in here has already been resolved (see above).
         tunnelStore.save(args).catch(() => {

--- a/client/src/cordova/apple/OutlineAppleLib/Sources/OutlineTunnel/OutlineVpn.swift
+++ b/client/src/cordova/apple/OutlineAppleLib/Sources/OutlineTunnel/OutlineVpn.swift
@@ -82,21 +82,21 @@ public class OutlineVpn: NSObject {
   // MARK: Interface
 
   // Starts a VPN tunnel as specified in the OutlineTunnel object.
-  public func start(_ tunnelId: String, configJson: [String: Any], _ completion: @escaping (Callback)) {
+  public func start(_ tunnelId: String, name: String?, configJson: [String: Any], _ completion: @escaping (Callback)) {
     guard !isActive(tunnelId) else {
       return completion(ErrorCode.noError)
     }
     if isVpnConnected() {
       return restartVpn(tunnelId, configJson: configJson, completion: completion)
     }
-    self.startVpn(tunnelId, configJson: configJson, isAutoConnect: false, completion)
+    self.startVpn(tunnelId, withName: name, configJson: configJson, isAutoConnect: false, completion)
   }
 
   // Starts the last successful VPN tunnel.
   @objc public func startLastSuccessfulTunnel(_ completion: @escaping (Callback)) {
     // Explicitly pass an empty tunnel's configuration, so the VpnExtension process retrieves
     // the last configuration from disk.
-    self.startVpn(nil, configJson:nil, isAutoConnect: true, completion)
+    self.startVpn(nil, withName: nil, configJson:nil, isAutoConnect: true, completion)
   }
 
   // Tears down the VPN if the tunnel with id |tunnelId| is active.
@@ -122,8 +122,9 @@ public class OutlineVpn: NSObject {
 
   // MARK: Helpers
 
-  private func startVpn(_ tunnelId: String?, configJson: [String: Any]?, isAutoConnect: Bool, _ completion: @escaping(Callback)) {
-    setupVpn() { error in
+  private func startVpn(_ tunnelId: String?, withName optionalName: String?, configJson: [String: Any]?, isAutoConnect: Bool, _ completion: @escaping(Callback)) {
+    // TODO(fortuna): Use localized name.
+    setupVpn(withName: optionalName ?? "Outline Server") { error in
       if error != nil {
         DDLogError("Failed to setup VPN: \(String(describing: error))")
         return completion(ErrorCode.vpnPermissionNotGranted);
@@ -173,7 +174,7 @@ public class OutlineVpn: NSObject {
 
   // Adds a VPN configuration to the user preferences if no Outline profile is present. Otherwise
   // enables the existing configuration.
-  private func setupVpn(completion: @escaping(Error?) -> Void) {
+  private func setupVpn(withName name:String, completion: @escaping(Error?) -> Void) {
     NETunnelProviderManager.loadAllFromPreferences() { (managers, error) in
       if let error = error {
         DDLogError("Failed to load VPN configuration: \(error)")
@@ -182,6 +183,8 @@ public class OutlineVpn: NSObject {
       var manager: NETunnelProviderManager!
       if let managers = managers, managers.count > 0 {
         manager = managers.first
+        // TODO: dedupe this with the call below.
+        manager.localizedDescription = name
         let hasOnDemandRules = !(manager.onDemandRules?.isEmpty ?? true)
         if manager.isEnabled && hasOnDemandRules {
           self.tunnelManager = manager
@@ -189,10 +192,12 @@ public class OutlineVpn: NSObject {
         }
       } else {
         let config = NETunnelProviderProtocol()
-        config.providerBundleIdentifier = OutlineVpn.kVpnExtensionBundleId
+        // TODO(fortuna): set to something meaningful if we can.
         config.serverAddress = "Outline"
+        config.providerBundleIdentifier = OutlineVpn.kVpnExtensionBundleId
 
         manager = NETunnelProviderManager()
+        manager.localizedDescription = name
         manager.protocolConfiguration = config
       }
       // Set an on-demand rule to connect to any available network to implement auto-connect on boot

--- a/client/src/cordova/plugin/android/java/org/outline/OutlinePlugin.java
+++ b/client/src/cordova/plugin/android/java/org/outline/OutlinePlugin.java
@@ -190,7 +190,9 @@ public class OutlinePlugin extends CordovaPlugin {
         // Tunnel instance actions: tunnel ID is always the first argument.
         if (Action.START.is(action)) {
           final String tunnelId = args.getString(0);
-          final JSONObject config = args.getJSONObject(1);
+          // TODO(fortuna): use serviceName.
+          // final String name = args.getString(1);
+          final JSONObject config = args.getJSONObject(2);
           int errorCode = startVpnTunnel(tunnelId, config);
           sendErrorCode(callback, errorCode);
         } else if (Action.STOP.is(action)) {

--- a/client/src/cordova/plugin/apple/src/OutlinePlugin.swift
+++ b/client/src/cordova/plugin/apple/src/OutlinePlugin.swift
@@ -83,13 +83,17 @@ class OutlinePlugin: CDVPlugin {
             return sendError("Missing tunnel ID", callbackId: command.callbackId,
                              errorCode: OutlineVpn.ErrorCode.illegalServerConfiguration)
         }
-        DDLogInfo("\(Action.start) \(tunnelId)")
+        guard let name = command.argument(at: 1) as? String else {
+            return sendError("Missing service name", callbackId: command.callbackId,
+                             errorCode: OutlineVpn.ErrorCode.illegalServerConfiguration)
+        }
+        DDLogInfo("\(Action.start) \(name) (\(tunnelId))")
         // TODO(fortuna): Move the config validation to the config parsing code in Go.
-        guard let configJson = command.argument(at: 1) as? [String: Any], containsExpectedKeys(configJson) else {
+        guard let configJson = command.argument(at: 2) as? [String: Any], containsExpectedKeys(configJson) else {
             return sendError("Invalid configuration", callbackId: command.callbackId,
                              errorCode: OutlineVpn.ErrorCode.illegalServerConfiguration)
         }
-        OutlineVpn.shared.start(tunnelId, configJson:configJson) { errorCode in
+      OutlineVpn.shared.start(tunnelId, name:name, configJson:configJson) { errorCode in
             if errorCode == OutlineVpn.ErrorCode.noError {
 #if os(macOS) || targetEnvironment(macCatalyst)
                 NotificationCenter.default.post(name: .kVpnConnected, object: nil)

--- a/client/src/www/app/outline_server_repository/server.cordova.ts
+++ b/client/src/www/app/outline_server_repository/server.cordova.ts
@@ -19,11 +19,11 @@ import {OUTLINE_PLUGIN_NAME, pluginExecWithErrorCode} from '../plugin.cordova';
 export class CordovaTunnel implements PlatformTunnel {
   constructor(public id: string) {}
 
-  start(config: ShadowsocksSessionConfig) {
+  start(name: string, config: ShadowsocksSessionConfig) {
     if (!config) {
       throw new errors.IllegalServerConfiguration();
     }
-    return pluginExecWithErrorCode<void>('start', this.id, config);
+    return pluginExecWithErrorCode<void>('start', this.id, name, config);
   }
 
   stop() {

--- a/client/src/www/app/outline_server_repository/server.electron.ts
+++ b/client/src/www/app/outline_server_repository/server.electron.ts
@@ -31,7 +31,7 @@ export class ElectronTunnel implements PlatformTunnel {
     });
   }
 
-  async start(config: ShadowsocksSessionConfig) {
+  async start(name: string, config: ShadowsocksSessionConfig) {
     if (this.running) {
       return Promise.resolve();
     }
@@ -41,7 +41,7 @@ export class ElectronTunnel implements PlatformTunnel {
     });
 
     try {
-      await window.electron.methodChannel.invoke('start-proxying', {config, id: this.id});
+      await window.electron.methodChannel.invoke('start-proxying', {id: this.id, serviceName: name, config});
       this.running = true;
     } catch (e) {
       throw PlatformError.parseFrom(e);

--- a/client/src/www/app/outline_server_repository/server.fake.ts
+++ b/client/src/www/app/outline_server_repository/server.fake.ts
@@ -34,7 +34,7 @@ export class FakeTunnel implements PlatformTunnel {
     return hostname === FAKE_UNREACHABLE_HOSTNAME;
   }
 
-  async start(config: ShadowsocksSessionConfig): Promise<void> {
+  async start(_name: string, config: ShadowsocksSessionConfig): Promise<void> {
     if (this.running) {
       return;
     }

--- a/client/src/www/app/outline_server_repository/server.ts
+++ b/client/src/www/app/outline_server_repository/server.ts
@@ -98,7 +98,7 @@ export class OutlineServer implements Server {
     }
 
     try {
-      await this.tunnel.start(this.sessionConfig);
+      await this.tunnel.start(this.name, this.sessionConfig);
     } catch (cause) {
       // TODO(junyi): Remove the catch above once all platforms are migrated to PlatformError
       if (cause instanceof PlatformError) {
@@ -164,7 +164,7 @@ export interface PlatformTunnel {
   // If there is another running instance, broadcasts a disconnect event and stops the active
   // tunnel. In such case, restarts tunneling while preserving the VPN.
   // Throws OutlinePluginError.
-  start(config: ShadowsocksSessionConfig): Promise<void>;
+  start(name: string, config: ShadowsocksSessionConfig): Promise<void>;
 
   // Stops the tunnel and VPN service.
   stop(): Promise<void>;


### PR DESCRIPTION
In this PR I forward the service name to the all the platform-specific code.
This allows us to use the name in UI (Android foreground service notification, Apple VPN profile, log messages), without digging into the config. This moves towards making the code config-agnostic.

In the process, I started using the service name in the Apple VPN profile, allowing the OS to display the service name:

![image](https://github.com/user-attachments/assets/b480122e-183c-4cde-87e5-8b8ada33660a)

![image](https://github.com/user-attachments/assets/76aabd17-2bef-488f-a0a7-88abe68057b0)

On Electron, we now display the name in log messages.

While Android is now receiving the service name, it's not yet using it.