### PR TITLE
chore(client): pass transport as string on Android and Apple

### DIFF
--- a/client/src/cordova/android/OutlineAndroidLib/outline/src/main/aidl/org/outline/IVpnTunnelService.aidl
+++ b/client/src/cordova/android/OutlineAndroidLib/outline/src/main/aidl/org/outline/IVpnTunnelService.aidl
@@ -30,12 +30,11 @@ interface IVpnTunnelService {
    * extra with the result of the operation, as defined in OutlinePlugin.ErrorCode. Displays a
    * persistent notification for the duration of the tunnel.
    *
-   * @param serverName the server to which this tunnel connects.
    * @param config tunnel configuration parameters.
    * @param isAutoStart boolean whether the tunnel was started without user intervention.
    * @return error code as defined in OutlinePlugin.ErrorCode.
    */
-  int startTunnel(String serverName, in TunnelConfig config);
+  int startTunnel(in TunnelConfig config);
 
   /**
    * Tears down a tunnel started by calling `startTunnel`. Stops tun2socks, shadowsocks, and

--- a/client/src/cordova/android/OutlineAndroidLib/outline/src/main/aidl/org/outline/TunnelConfig.aidl
+++ b/client/src/cordova/android/OutlineAndroidLib/outline/src/main/aidl/org/outline/TunnelConfig.aidl
@@ -14,10 +14,8 @@
 
 package org.outline;
 
-import org.outline.shadowsocks.ShadowsocksConfig;
-
 parcelable TunnelConfig {
   String id;
   String name;
-  ShadowsocksConfig proxy;
+  String transportConfig;
 }

--- a/client/src/cordova/android/OutlineAndroidLib/outline/src/main/java/org/outline/vpn/VpnTunnelService.java
+++ b/client/src/cordova/android/OutlineAndroidLib/outline/src/main/java/org/outline/vpn/VpnTunnelService.java
@@ -38,7 +38,6 @@ import org.json.JSONObject;
 import org.outline.IVpnTunnelService;
 import org.outline.TunnelConfig;
 import org.outline.log.SentryErrorReporter;
-import org.outline.shadowsocks.ShadowsocksConfig;
 import shadowsocks.Shadowsocks;
 
 /**
@@ -112,8 +111,8 @@ public class VpnTunnelService extends VpnService {
 
   private final IVpnTunnelService.Stub binder = new IVpnTunnelService.Stub() {
     @Override
-    public int startTunnel(String serverName, TunnelConfig config) {
-      return VpnTunnelService.this.startTunnel(serverName, config).value;
+    public int startTunnel(TunnelConfig config) {
+      return VpnTunnelService.this.startTunnel(config).value;
     }
 
     @Override
@@ -191,63 +190,16 @@ public class VpnTunnelService extends VpnService {
     return new VpnService.Builder();
   }
 
-  /**
-   * Helper method to build a TunnelConfig from a JSON object.
-   *
-   * @param tunnelId unique identifier for the tunnel.
-   * @param config JSON object containing TunnelConfig values.
-   * @throws IllegalArgumentException if `tunnelId` or `config` are null.
-   * @throws JSONException if parsing `config` fails.
-   * @return populated TunnelConfig
-   */
-  public static TunnelConfig makeTunnelConfig(final String tunnelId, final JSONObject config)
-      throws Exception {
-    if (tunnelId == null || config == null) {
-      throw new IllegalArgumentException("Must provide a tunnel ID and JSON configuration");
-    }
-    final TunnelConfig tunnelConfig = new TunnelConfig();
-    tunnelConfig.id = tunnelId;
-    tunnelConfig.proxy = new ShadowsocksConfig();
-    tunnelConfig.proxy.host = config.getString("host");
-    tunnelConfig.proxy.port = config.getInt("port");
-    tunnelConfig.proxy.password = config.getString("password");
-    tunnelConfig.proxy.method = config.getString("method");
-    // `name` and `prefix` are optional properties.
-    try {
-      tunnelConfig.name = config.getString("name");
-    } catch (JSONException e) {
-      LOG.fine("Tunnel config missing name");
-    }
-    String prefix = null;
-    try {
-      prefix = config.getString("prefix");
-      LOG.fine("Activating experimental prefix support");
-    } catch (JSONException e) {
-      // pass
-    }
-    if (prefix != null) {
-      tunnelConfig.proxy.prefix = new byte[prefix.length()];
-      for (int i = 0; i < prefix.length(); i++) {
-        char c = prefix.charAt(i);
-        if ((c & 0xFF) != c) {
-          throw new JSONException(String.format("Prefix character '%c' is out of range", c));
-        }
-        tunnelConfig.proxy.prefix[i] = (byte)c;
-      }
-    }
-    return tunnelConfig;
-  }
-
   // Tunnel API
 
-  private ErrorCode startTunnel(final String serverName, final TunnelConfig config) {
-    return startTunnel(config, serverName, false);
+  private ErrorCode startTunnel(final TunnelConfig config) {
+    return startTunnel(config, false);
   }
 
   private synchronized ErrorCode startTunnel(
-      final TunnelConfig config, final String serverName, boolean isAutoStart) {
-    LOG.info(String.format(Locale.ROOT, "Starting tunnel %s for server %s", config.id, serverName));
-    if (config.id == null || config.proxy == null) {
+      final TunnelConfig config, boolean isAutoStart) {
+    LOG.info(String.format(Locale.ROOT, "Starting tunnel %s for server %s", config.id, config.name));
+    if (config.id == null || config.transportConfig == null) {
       return ErrorCode.ILLEGAL_SERVER_CONFIGURATION;
     }
     final boolean isRestart = tunnelConfig != null;
@@ -263,15 +215,9 @@ public class VpnTunnelService extends VpnService {
       }
     }
 
-    final shadowsocks.Config configCopy = new shadowsocks.Config();
-    configCopy.setHost(config.proxy.host);
-    configCopy.setPort(config.proxy.port);
-    configCopy.setCipherName(config.proxy.method);
-    configCopy.setPassword(config.proxy.password);
-    configCopy.setPrefix(config.proxy.prefix);
     final shadowsocks.Client client;
     try {
-      client = new shadowsocks.Client(configCopy);
+      client = new shadowsocks.Client(config.transportConfig);
     } catch (Exception e) {
       LOG.log(Level.WARNING, "Invalid configuration", e);
       tearDownActiveTunnel();
@@ -315,8 +261,8 @@ public class VpnTunnelService extends VpnService {
       tearDownActiveTunnel();
       return ErrorCode.VPN_START_FAILURE;
     }
-    startForegroundWithNotification(serverName);
-    storeActiveTunnel(config, serverName, remoteUdpForwardingEnabled);
+    startForegroundWithNotification(config.name);
+    storeActiveTunnel(config, remoteUdpForwardingEnabled);
     return ErrorCode.NO_ERROR;
   }
 
@@ -367,7 +313,7 @@ public class VpnTunnelService extends VpnService {
   // Connectivity
 
   private class NetworkConnectivityMonitor extends ConnectivityManager.NetworkCallback {
-    private ConnectivityManager connectivityManager;
+    private final ConnectivityManager connectivityManager;
 
     public NetworkConnectivityMonitor() {
       this.connectivityManager =
@@ -473,40 +419,26 @@ public class VpnTunnelService extends VpnService {
       return;
     }
     try {
-      final String tunnelId = tunnel.getString(TUNNEL_ID_KEY);
-      final JSONObject jsonConfig = tunnel.getJSONObject(TUNNEL_CONFIG_KEY);
-      final String serverName = tunnel.getString(TUNNEL_SERVER_NAME);
-      final TunnelConfig config = makeTunnelConfig(tunnelId, jsonConfig);
+      final TunnelConfig tunnelConfig = new TunnelConfig();
+      tunnelConfig.id = tunnel.getString(TUNNEL_ID_KEY);
+      tunnelConfig.name = tunnel.getString(TUNNEL_SERVER_NAME);
+      tunnelConfig.transportConfig = tunnel.getString(TUNNEL_CONFIG_KEY);
+
       // Start the service in the foreground as per Android 8+ background service execution limits.
       // Requires android.permission.FOREGROUND_SERVICE since Android P.
-      startForegroundWithNotification(serverName);
-      startTunnel(config, serverName, true);
+      startForegroundWithNotification(tunnelConfig.name);
+      startTunnel(tunnelConfig, true);
     } catch (Exception e) {
       LOG.log(Level.SEVERE, "Failed to retrieve JSON tunnel data", e);
     }
   }
 
-  private void storeActiveTunnel(final TunnelConfig config, final String serverName, boolean isUdpSupported) {
+  private void storeActiveTunnel(final TunnelConfig config, boolean isUdpSupported) {
     LOG.info("Storing active tunnel.");
     JSONObject tunnel = new JSONObject();
     try {
-      JSONObject proxyConfig = new JSONObject();
-      proxyConfig.put("host", config.proxy.host);
-      proxyConfig.put("port", config.proxy.port);
-      proxyConfig.put("password", config.proxy.password);
-      proxyConfig.put("method", config.proxy.method);
-
-      if (config.proxy.prefix != null) {
-        char[] chars = new char[config.proxy.prefix.length];
-        for (int i = 0; i < config.proxy.prefix.length; i++) {
-          // Unsigned bit width extension requires a mask in Java.
-          chars[i] = (char)(config.proxy.prefix[i] & 0xFF);
-        }
-        proxyConfig.put("prefix", new String(chars));
-      }
-
       tunnel.put(TUNNEL_ID_KEY, config.id).put(
-        TUNNEL_CONFIG_KEY, proxyConfig).put(TUNNEL_SERVER_NAME, serverName);
+        TUNNEL_CONFIG_KEY, config.transportConfig).put(TUNNEL_SERVER_NAME, config.name);
       tunnelStore.save(tunnel);
     } catch (JSONException e) {
       LOG.log(Level.SEVERE, "Failed to store JSON tunnel data", e);

--- a/client/src/cordova/plugin/android/java/org/outline/OutlinePlugin.java
+++ b/client/src/cordova/plugin/android/java/org/outline/OutlinePlugin.java
@@ -190,8 +190,8 @@ public class OutlinePlugin extends CordovaPlugin {
         if (Action.START.is(action)) {
           final String tunnelId = args.getString(0);
           final String serverName = args.getString(1);
-          final JSONObject config = args.getJSONObject(2);
-          int errorCode = startVpnTunnel(tunnelId, config, serverName);
+          final String transportConfig = args.getString(2);
+          int errorCode = startVpnTunnel(tunnelId, transportConfig, serverName);
           sendErrorCode(callback, errorCode);
         } else if (Action.STOP.is(action)) {
           final String tunnelId = args.getString(0);
@@ -254,16 +254,13 @@ public class OutlinePlugin extends CordovaPlugin {
     startVpnRequest = null;
   }
 
-  private int startVpnTunnel(final String tunnelId, final JSONObject config, final String serverName) throws Exception {
+  private int startVpnTunnel(final String tunnelId, final String transportConfig, final String serverName) throws Exception {
     LOG.info(String.format(Locale.ROOT, "Starting VPN tunnel %s for server %s", tunnelId, serverName));
-    final TunnelConfig tunnelConfig;
-    try {
-      tunnelConfig = VpnTunnelService.makeTunnelConfig(tunnelId, config);
-    } catch (Exception e) {
-      LOG.log(Level.SEVERE, "Failed to retrieve the tunnel proxy config.", e);
-      return ErrorCode.ILLEGAL_SERVER_CONFIGURATION.value;
-    }
-    return vpnTunnelService.startTunnel(serverName, tunnelConfig);
+    final TunnelConfig tunnelConfig = new TunnelConfig();
+    tunnelConfig.id = tunnelId;
+    tunnelConfig.name = serverName;
+    tunnelConfig.transportConfig = transportConfig;
+    return vpnTunnelService.startTunnel(tunnelConfig);
   }
 
   // Returns whether the VPN service is running a particular tunnel instance.

--- a/client/src/cordova/plugin/apple/src/OutlinePlugin.swift
+++ b/client/src/cordova/plugin/apple/src/OutlinePlugin.swift
@@ -96,10 +96,7 @@ class OutlinePlugin: CDVPlugin {
                          errorCode: OutlineVpn.ErrorCode.illegalServerConfiguration)
       }
       DDLogInfo("\(Action.start) \(name) (\(tunnelId))")
-      // TODO(fortuna): Move the config validation to the config parsing code in Go.
-      guard let transportConfigJson = command.argument(at: 2) as? [String: Any],
-        let transportConfigJsonData = try? JSONSerialization.data(withJSONObject: transportConfigJson, options: []),
-        let transportConfig = String(data: transportConfigJsonData, encoding: .utf8) else {
+      guard let transportConfig = command.argument(at: 2) as? String else {
         return sendError("Invalid configuration", callbackId: command.callbackId,
                          errorCode: OutlineVpn.ErrorCode.illegalServerConfiguration)
       }

--- a/client/src/www/app/outline_server_repository/vpn.cordova.ts
+++ b/client/src/www/app/outline_server_repository/vpn.cordova.ts
@@ -19,11 +19,16 @@ import {OUTLINE_PLUGIN_NAME, pluginExecWithErrorCode} from '../plugin.cordova';
 export class CordovaVpnApi implements VpnApi {
   constructor() {}
 
-  start(id: string, name: string, config: ShadowsocksSessionConfig) {
-    if (!config) {
+  start(id: string, name: string, transportConfig: ShadowsocksSessionConfig) {
+    if (!transportConfig) {
       throw new errors.IllegalServerConfiguration();
     }
-    return pluginExecWithErrorCode<void>('start', id, name, config);
+    return pluginExecWithErrorCode<void>(
+      'start',
+      id,
+      name,
+      JSON.stringify(transportConfig)
+    );
   }
 
   stop(id: string) {


### PR DESCRIPTION
This cleans up TunnelConfig on Android, passing the transport as an opaque string.
On Apple, we complete the migration by sending a string from Typescript.

/cc @62w71st