### PR TITLE
chore(client): remove duplicate "Cancel" message

### DIFF
--- a/client/resources/original_messages.json
+++ b/client/resources/original_messages.json
@@ -52,14 +52,6 @@
     "description": "An error message shown when the user tries to add a server with an invalid access key.",
     "message": "Invalid access key."
   },
-  "add_access_key_dialog_cancel": {
-    "description": "The text on a button to cancel the adding of an access key.",
-    "message": "Cancel"
-  },
-  "add_access_key_dialog_confirm": {
-    "desciption": "The text on a button to confirm the adding of an access key.",
-    "message": "Confirm"
-  },
   "auto_connect_dialog_detail": {
     "description": "An explanation of the connection behavior of the app. Outline is the product name and can be found in the translation glossary.",
     "message": "Unless you disconnect from your Outline server, Outline will automatically connect next time you restart your device."
@@ -79,6 +71,10 @@
   "close": {
     "description": "The text for a button to close the current page or dialog.",
     "message": "Close"
+  },
+  "confirm": {
+    "desciption": "The text on a button to confirm the current operation.",
+    "message": "Confirm"
   },
   "connect_button_label": {
     "description": "A text button on a particular server to connect to that server",

--- a/client/src/www/views/root_view/add_access_key_dialog/index.ts
+++ b/client/src/www/views/root_view/add_access_key_dialog/index.ts
@@ -96,12 +96,12 @@ export class AddAccessKeyDialog extends LitElement {
       </article>
       <fieldset slot="actions">
         <md-text-button @click=${this.handleCancel}>
-          ${this.localize('add-access-key-dialog-cancel')}
+          ${this.localize('cancel')}
         </md-text-button>
         <md-filled-button
           @click=${this.handleConfirm}
           ?disabled=${!this.hasValidAccessKey}
-          >${this.localize('add-access-key-dialog-confirm')}</md-filled-button
+          >${this.localize('confirm')}</md-filled-button
         >
       </fieldset>
     </md-dialog>`;


### PR DESCRIPTION
This breaks the l10n build. We could probably disambiguate with a meaning attribute, but it's easier to just re-use the same message as we use "Cancel" for dialogs across many other places.

Changing "Confirm" to also be more generic so it can be re-used.