### PR TITLE
fix(client): dynamic key config parsing regression

### DIFF
--- a/client/go/outline/config.go
+++ b/client/go/outline/config.go
@@ -52,6 +52,9 @@ type configJSON struct {
 	Password string `json:"password"`
 	Method   string `json:"method"`
 	Prefix   string `json:"prefix"`
+
+	DynamicKeyServer     string `json:"server"`
+	DynamicKeyServerPort uint16 `json:"server_port"`
 }
 
 // ParseConfigFromJSON parses a JSON string `in` as a configJSON object.
@@ -61,6 +64,12 @@ func parseConfigFromJSON(in string) (*configJSON, error) {
 	var conf configJSON
 	if err := json.Unmarshal([]byte(in), &conf); err != nil {
 		return nil, err
+	}
+	if conf.Host == "" {
+		conf.Host = conf.DynamicKeyServer
+	}
+	if conf.Port == 0 {
+		conf.Port = conf.DynamicKeyServerPort
 	}
 	return &conf, nil
 }


### PR DESCRIPTION
This PR fixes a regression caused by #2192 , where the [dynamic key JSON fields `server` and `server_port`](https://www.reddit.com/r/outlinevpn/wiki/index/dynamic_access_keys/) were ignored.

The Go code now accepts both `host`+`port` and `server`+`server_port`.


The following screenshots are taken when using this key for test : https://github.com/jyyi1/jyyibin/raw/main/keys/unreachable . We expect a `ServerUnreachable` error, instead of a `UnexpectedPluginError`.

**Expected (Left) v.s. Current (Right)**

<img width="300" src="https://github.com/user-attachments/assets/666ddf0f-f0d4-4db5-90b4-ae138744541e" />

<img width="300" src="https://github.com/user-attachments/assets/2ac5d623-8dd5-4c11-a005-0e6fe9f3a8a6" />
