### PR TITLE
fix(client/windows): restore product name to "Outline"

### DIFF
--- a/client/electron/electron-builder.json
+++ b/client/electron/electron-builder.json
@@ -1,5 +1,5 @@
 {
-  "productName": "outline-client",
+  "productName": "Outline",
   "artifactName": "Outline-Client.${ext}",
   "asarUnpack": [ "client" ],
   "directories": {


### PR DESCRIPTION
This commit reverts the product name from "outline-client" back to "Outline".

This also fixed the reinstallation issue. Though I'm still not sure about the root cause, it could be that electron-builder failed to handle the '-' character (similar to https://github.com/electron-userland/electron-builder/issues/6488, but not exactly the same).