### PR TITLE
ci(devtools): fix PR commitlint workflow

### DIFF
--- a/.github/workflows/pull_request_checks.yml
+++ b/.github/workflows/pull_request_checks.yml
@@ -49,7 +49,7 @@ jobs:
         run: npm ci
 
       - name: Ensure Commitizen Format
-        uses: JulienKode/pull-request-name-linter-action@v0.5.0
+        uses: JulienKode/pull-request-name-linter-action@98794a8b815ec05560813c42e55fd8d32d3fd248
 
   size_label:
     name: Change Size Label


### PR DESCRIPTION
Reverting the upgrade since it breaks our scopes that uses `/`.