### PR TITLE
fix(client): disable selectability of logo text

### DIFF
--- a/client/src/www/views/root_view/root_header/index.ts
+++ b/client/src/www/views/root_view/root_header/index.ts
@@ -37,6 +37,7 @@ export class RootHeader extends LitElement {
       font-size: 24px;
       font-weight: 500;
       margin: 0;
+      user-select: none;
     }
 
     md-icon {


### PR DESCRIPTION
* Updated `h1` styles in the root view to prevent the logo text from being selectable