### PR TITLE
fix(client/ios): filter `AppKitIntegration` framework to `maccatalyst`

### DIFF
--- a/client/src/cordova/apple/xcode/ios/Outline.xcodeproj/project.pbxproj
+++ b/client/src/cordova/apple/xcode/ios/Outline.xcodeproj/project.pbxproj
@@ -21,7 +21,7 @@
 		5F7F90AE0E924FD7B065C415 /* CDVStatusBar.m in Sources */ = {isa = PBXBuildFile; fileRef = 0394302BA6114B2AB648D4FF /* CDVStatusBar.m */; };
 		65A9AC9C2BEC091700C5899F /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 65A9AC9B2BEC091700C5899F /* PrivacyInfo.xcprivacy */; };
 		6AFF5BF91D6E424B00AB3073 /* CDVLaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 6AFF5BF81D6E424B00AB3073 /* CDVLaunchScreen.storyboard */; };
-		A246B7E52B07AADD00ECACD5 /* AppKitIntegration.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = A246B7DD2B07AACF00ECACD5 /* AppKitIntegration.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		A246B7E52B07AADD00ECACD5 /* AppKitIntegration.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = A246B7DD2B07AACF00ECACD5 /* AppKitIntegration.framework */; platformFilter = maccatalyst; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		A25FB7DC2B0D4420009B6B5F /* AppKitIntegration.h in Headers */ = {isa = PBXBuildFile; fileRef = A272490D2B0D20530018A598 /* AppKitIntegration.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		A271D42D2A708240009981B2 /* AppDelegate+Outline.m in Sources */ = {isa = PBXBuildFile; fileRef = A271D42C2A708240009981B2 /* AppDelegate+Outline.m */; };
 		A271D4342A70829D009981B2 /* OutlineAppleLib in Frameworks */ = {isa = PBXBuildFile; productRef = A271D4332A70829D009981B2 /* OutlineAppleLib */; };
@@ -692,6 +692,7 @@
 		};
 		A246B7E72B07AADD00ECACD5 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
+			platformFilter = maccatalyst;
 			target = A246B7DC2B07AACF00ECACD5 /* AppKitIntegration */;
 			targetProxy = A246B7E62B07AADD00ECACD5 /* PBXContainerItemProxy */;
 		};


### PR DESCRIPTION
This platform filter was accidentally removed in #2090 and causing asset validation issues for the iOS app:

```
Asset validation failed
This bundle is invalid. Applications built for more than one architecture require an iOS Deployment Target of 3.0 or later. (ID: ec5bf398-a85e-4069-a03f-9b7cb51b40c4)

Asset validation failed
Unsupported Architectures. The executable for Outline.app/Frameworks/AppKitIntegration.framework contains unsupported architectures '[x86_64]'. (ID: 72745965-6014-4983-9631-028f7a57c917)

Asset validation failed
Invalid bundle structure. The “Outline.app/Frameworks/AppKitIntegration.framework/Versions/A/AppKitIntegration” binary file is not permitted. Your app cannot contain standalone executables or libraries, other than a valid CFBundleExecutable of supported bundles. For details, visit: https://developer.apple.com/documentation/bundleresources/placing_content_in_a_bundle (ID: a4bf6667-5817-46c6-b175-9d4dbc889d5f)

Asset validation failed
Missing Info.plist value. A value for the key 'MinimumOSVersion' in bundle Outline.app/Frameworks/AppKitIntegration.framework is required. (ID: 446cd137-ed5d-4739-8b15-cd2148017874)

Asset validation failed
Invalid Segment Alignment. The app binary at 'Outline.app/Frameworks/AppKitIntegration.framework/AppKitIntegration' does not have proper segment alignment. Try rebuilding the app with the latest Xcode version. (ID: 25fe97fe-0caa-4818-b300-ac123462192c)

Asset validation failed
Invalid Segment Alignment. The app binary at 'Outline.app/Frameworks/AppKitIntegration.framework/Versions/A/AppKitIntegration' does not have proper segment alignment. Try rebuilding the app with the latest Xcode version. (ID: b3588581-58e7-4822-8b55-e380dfa2bc78)

Asset validation failed
The binary is invalid. The encryption info in the LC_ENCRYPTION_INFO load command is either missing or invalid, or the binary is already encrypted. This binary does not seem to have been built with Apple's linker. (ID: b4c38d6e-aaaa-45f4-9882-0a09c501a1ad)

Asset validation failed
Invalid Bundle. The bundle Outline.app/Frameworks/AppKitIntegration.framework does not support the minimum OS Version specified in the Info.plist. (ID: 2c802eb5-9e91-4a4e-87c6-c1e114473182)
```