### PR TITLE
refactor(client): reduce config library surface

### DIFF
--- a/client/electron/index.ts
+++ b/client/electron/index.ts
@@ -351,7 +351,7 @@ async function createVpnTunnel(
   // because startVpn will add a routing table entry that prefixed with this
   // host (e.g. "<host>/32"), therefore <host> must be an IP address.
   // TODO: make sure we resolve it in the native code
-  const host = config.getHostFromTransportConfig(tunnelConfig.transport);
+  const host = tunnelConfig.firstHop.host;
   if (!host) {
     throw new errors.IllegalServerConfiguration('host is missing');
   }

--- a/client/src/www/app/app.ts
+++ b/client/src/www/app/app.ts
@@ -227,7 +227,14 @@ export class App {
 
     this.eventQueue.startPublishing();
 
-    this.rootEl.$.addServerView.validateAccessKey = config.validateAccessKey;
+    this.rootEl.$.addServerView.isValidAccessKey = (accessKey: string) => {
+      try {
+        config.parseAccessKey(accessKey);
+        return true;
+      } catch {
+        return false;
+      }
+    };
     if (!this.arePrivacyTermsAcked()) {
       this.displayPrivacyView();
     } else if (this.rootEl.$.serversView.shouldShowZeroState) {

--- a/client/src/www/app/outline_server_repository/config.spec.ts
+++ b/client/src/www/app/outline_server_repository/config.spec.ts
@@ -74,7 +74,7 @@ describe('setTransportHost', () => {
 });
 
 describe('parseTunnelConfig', () => {
-  it('parse correctly', () => {
+  it('parses correctly', () => {
     expect(
       config.parseTunnelConfig(
         '{"server": "example.com", "server_port": 443, "method": "METHOD", "password": "PASSWORD"}'
@@ -93,7 +93,7 @@ describe('parseTunnelConfig', () => {
     });
   });
 
-  it('parse prefix', () => {
+  it('parses prefix', () => {
     expect(
       config.parseTunnelConfig(
         '{"server": "example.com", "server_port": 443, "method": "METHOD", "password": "PASSWORD", "prefix": "POST "}'
@@ -113,7 +113,7 @@ describe('parseTunnelConfig', () => {
     });
   });
 
-  it('parse URL', () => {
+  it('parses URL', () => {
     const ssUrl = SIP002_URI.stringify(
       makeConfig({
         host: 'example.com',
@@ -123,6 +123,29 @@ describe('parseTunnelConfig', () => {
       })
     );
     expect(config.parseTunnelConfig(ssUrl)).toEqual({
+      firstHop: {
+        host: 'example.com',
+        port: 443,
+      },
+      transport: {
+        host: 'example.com',
+        port: 443,
+        method: 'chacha20-ietf-poly1305',
+        password: 'PASSWORD',
+      },
+    });
+  });
+
+  it('parses URL with blanks', () => {
+    const ssUrl = SIP002_URI.stringify(
+      makeConfig({
+        host: 'example.com',
+        port: 443,
+        method: 'chacha20-ietf-poly1305',
+        password: 'PASSWORD',
+      })
+    );
+    expect(config.parseTunnelConfig(`  ${ssUrl} \n\n\n`)).toEqual({
       firstHop: {
         host: 'example.com',
         port: 443,

--- a/client/src/www/app/outline_server_repository/config.spec.ts
+++ b/client/src/www/app/outline_server_repository/config.spec.ts
@@ -19,36 +19,27 @@ import * as config from './config';
 describe('getAddressFromTransport', () => {
   it('extracts address', () => {
     expect(
-      config.getAddressFromTransportConfig({host: 'example.com', port: '443'})
-    ).toEqual('example.com:443');
+      config.TEST_ONLY.getAddressFromTransportConfig({
+        host: 'example.com',
+        port: 443,
+      })
+    ).toEqual({host: 'example.com', port: 443});
     expect(
-      config.getAddressFromTransportConfig({host: '1:2::3', port: '443'})
-    ).toEqual('[1:2::3]:443');
-    expect(config.getAddressFromTransportConfig({host: 'example.com'})).toEqual(
-      'example.com'
-    );
-    expect(config.getAddressFromTransportConfig({host: '1:2::3'})).toEqual(
-      '1:2::3'
-    );
+      config.TEST_ONLY.getAddressFromTransportConfig({
+        host: '1:2::3',
+        port: 443,
+      })
+    ).toEqual({host: '1:2::3', port: 443});
+    expect(
+      config.TEST_ONLY.getAddressFromTransportConfig({host: 'example.com'})
+    ).toEqual({host: 'example.com', port: undefined});
+    expect(
+      config.TEST_ONLY.getAddressFromTransportConfig({host: '1:2::3'})
+    ).toEqual({host: '1:2::3', port: undefined});
   });
 
   it('fails on invalid config', () => {
-    expect(config.getAddressFromTransportConfig({})).toBeUndefined();
-  });
-});
-
-describe('getHostFromTransport', () => {
-  it('extracts host', () => {
-    expect(
-      config.getHostFromTransportConfig({host: 'example.com', port: '443'})
-    ).toEqual('example.com');
-    expect(
-      config.getHostFromTransportConfig({host: '1:2::3', port: '443'})
-    ).toEqual('1:2::3');
-  });
-
-  it('fails on invalid config', () => {
-    expect(config.getHostFromTransportConfig({})).toBeUndefined();
+    expect(config.TEST_ONLY.getAddressFromTransportConfig({})).toBeUndefined();
   });
 });
 
@@ -57,24 +48,24 @@ describe('setTransportHost', () => {
     expect(
       JSON.stringify(
         config.setTransportConfigHost(
-          {host: 'example.com', port: '443'},
+          {host: 'example.com', port: 443},
           '1.2.3.4'
         )
       )
-    ).toEqual('{"host":"1.2.3.4","port":"443"}');
+    ).toEqual('{"host":"1.2.3.4","port":443}');
     expect(
       JSON.stringify(
         config.setTransportConfigHost(
-          {host: 'example.com', port: '443'},
+          {host: 'example.com', port: 443},
           '1:2::3'
         )
       )
-    ).toEqual('{"host":"1:2::3","port":"443"}');
+    ).toEqual('{"host":"1:2::3","port":443}');
     expect(
       JSON.stringify(
-        config.setTransportConfigHost({host: '1.2.3.4', port: '443'}, '1:2::3')
+        config.setTransportConfigHost({host: '1.2.3.4', port: 443}, '1:2::3')
       )
-    ).toEqual('{"host":"1:2::3","port":"443"}');
+    ).toEqual('{"host":"1:2::3","port":443}');
   });
 
   it('fails on invalid config', () => {
@@ -89,6 +80,10 @@ describe('parseTunnelConfig', () => {
         '{"server": "example.com", "server_port": 443, "method": "METHOD", "password": "PASSWORD"}'
       )
     ).toEqual({
+      firstHop: {
+        host: 'example.com',
+        port: 443,
+      },
       transport: {
         host: 'example.com',
         port: 443,
@@ -104,6 +99,10 @@ describe('parseTunnelConfig', () => {
         '{"server": "example.com", "server_port": 443, "method": "METHOD", "password": "PASSWORD", "prefix": "POST "}'
       )
     ).toEqual({
+      firstHop: {
+        host: 'example.com',
+        port: 443,
+      },
       transport: {
         host: 'example.com',
         port: 443,
@@ -124,6 +123,10 @@ describe('parseTunnelConfig', () => {
       })
     );
     expect(config.parseTunnelConfig(ssUrl)).toEqual({
+      firstHop: {
+        host: 'example.com',
+        port: 443,
+      },
       transport: {
         host: 'example.com',
         port: 443,
@@ -131,5 +134,25 @@ describe('parseTunnelConfig', () => {
         password: 'PASSWORD',
       },
     });
+  });
+});
+
+describe('serviceNameFromAccessKey', () => {
+  it('extracts name from ss:// key', () => {
+    expect(
+      config.TEST_ONLY.serviceNameFromAccessKey('ss://anything#My%20Server')
+    ).toEqual('My Server');
+  });
+  it('extracts name from ssconf:// key', () => {
+    expect(
+      config.TEST_ONLY.serviceNameFromAccessKey('ssconf://anything#My%20Server')
+    ).toEqual('My Server');
+  });
+  it('ignores parameters', () => {
+    expect(
+      config.TEST_ONLY.serviceNameFromAccessKey(
+        'ss://anything#foo=bar&My%20Server&baz=boo'
+      )
+    ).toEqual('My Server');
   });
 });

--- a/client/src/www/app/outline_server_repository/config.ts
+++ b/client/src/www/app/outline_server_repository/config.ts
@@ -106,6 +106,7 @@ export function setTransportConfigHost(
 export function parseTunnelConfig(
   tunnelConfigText: string
 ): TunnelConfigJson | null {
+  tunnelConfigText = tunnelConfigText.trim();
   if (tunnelConfigText.startsWith('ss://')) {
     return staticKeyToTunnelConfig(tunnelConfigText);
   }

--- a/client/src/www/app/outline_server_repository/config.ts
+++ b/client/src/www/app/outline_server_repository/config.ts
@@ -25,11 +25,9 @@ export const TEST_ONLY = {
  * ServiceConfig represents an Outline service. It's the structured representation of an Access Key.
  * It has a name, a tunnel config that can be statically or dynamically defined.
  */
-export type ServiceConfig = {
-  readonly name: string;
-} & (StaticServiceConfig | DynamicServiceConfig);
+export type ServiceConfig = StaticServiceConfig | DynamicServiceConfig;
 
-/** 
+/**
  * StaticServiceConfig is a ServiceConfig with a static tunnel config.
  * It's the structured representation of a Static Access Key.
  */
@@ -37,15 +35,12 @@ export class StaticServiceConfig {
   constructor(readonly name: string, readonly tunnelConfig: TunnelConfigJson) {}
 }
 
-/** 
+/**
  * DynamicServiceConfig is a ServiceConfig that has the location to fetch the tunnel config.
  * It's the structured representation of a Dynamic Access Key.
  */
 export class DynamicServiceConfig {
-  constructor(
-    readonly name: string,
-    readonly transportConfigLocation: URL
-  ) {}
+  constructor(readonly name: string, readonly transportConfigLocation: URL) {}
 }
 
 /** EndpointAddress represents the address of a TCP/UDP endpoint. */
@@ -105,7 +100,8 @@ export function setTransportConfigHost(
 /**
  * parseTunnelConfig parses the given tunnel config as text and returns a new TunnelConfigJson.
  * The config text may be a "ss://" link or a JSON object.
- * This is used by the server to parse the config fetched from the dynamic key.
+ * This is used by the server to parse the config fetched from the dynamic key, and to parse
+ * static keys as tunnel configs (which may be present in the dynamic config).
  */
 export function parseTunnelConfig(
   tunnelConfigText: string

--- a/client/src/www/app/outline_server_repository/config.ts
+++ b/client/src/www/app/outline_server_repository/config.ts
@@ -12,16 +12,44 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import * as net from '@outline/infrastructure/net';
 import {SHADOWSOCKS_URI} from 'ShadowsocksConfig';
 
 import * as errors from '../../model/errors';
+
+export const TEST_ONLY = {
+  getAddressFromTransportConfig: getAddressFromTransportConfig,
+  serviceNameFromAccessKey: serviceNameFromAccessKey,
+};
+
+export type ServiceConfig = {
+  readonly name: string;
+} & (StaticServiceConfig | DynamicServiceConfig);
+
+export class StaticServiceConfig {
+  constructor(
+    readonly name: string,
+    readonly tunnelconfig: TunnelConfigJson
+  ) {}
+}
+
+export class DynamicServiceConfig {
+  constructor(
+    readonly name: string,
+    readonly transportConfigLocation: URL
+  ) {}
+}
+
+class EndpointAddress {
+  readonly host: string;
+  readonly port: number | undefined;
+}
 
 // Transport configuration. Application code should treat it as opaque, as it's handled by the networking layer.
 export type TransportConfigJson = object;
 
 /** TunnelConfigJson represents the configuration to set up a tunnel. */
 export interface TunnelConfigJson {
+  firstHop: EndpointAddress | undefined;
   /** transport describes how to establish connections to the destinations.
    * See https://github.com/Jigsaw-Code/outline-apps/blob/master/client/go/outline/config.go for format. */
   transport: TransportConfigJson;
@@ -31,27 +59,15 @@ export interface TunnelConfigJson {
  * getAddressFromTransportConfig returns the address of the tunnel server, if there's a meaningful one.
  * This is used to show the server address in the UI when connected.
  */
-export function getAddressFromTransportConfig(
+function getAddressFromTransportConfig(
   transport: TransportConfigJson
-): string | undefined {
-  const hostConfig: {host?: string; port?: string} = transport;
-  if (hostConfig.host && hostConfig.port) {
-    return net.joinHostPort(hostConfig.host, hostConfig.port);
-  } else if (hostConfig.host) {
-    return hostConfig.host;
+): EndpointAddress | undefined {
+  const hostConfig: {host?: string; port?: number} = transport;
+  if (hostConfig.host) {
+    return {host: hostConfig.host, port: hostConfig?.port};
   } else {
     return undefined;
   }
-}
-
-/**
- * getHostFromTransportConfig returns the host of the tunnel server, if there's a meaningful one.
- * This is used by the proxy resolution in Electron.
- */
-export function getHostFromTransportConfig(
-  transport: TransportConfigJson
-): string | undefined {
-  return (transport as unknown as {host: string | undefined}).host;
 }
 
 /**
@@ -59,6 +75,7 @@ export function getHostFromTransportConfig(
  * Should only be set if getHostFromTransportConfig returns one.
  * This is used by the proxy resolution in Electron.
  */
+// TODO(fortuna): Move config parsing to Go and do the DNS resolution and IP injection for Electron there.
 export function setTransportConfigHost(
   transport: TransportConfigJson,
   newHost: string
@@ -90,6 +107,9 @@ export function parseTunnelConfig(
     );
   }
 
+  // TODO(fortuna): stop converting to the Go format. Let the Go code convert.
+  // We don't validate the method because that's already done in the Go code as
+  // part of the Dynamic Key connection flow.
   const transport: TransportConfigJson = {
     host: responseJson.server,
     port: responseJson.server_port,
@@ -99,57 +119,70 @@ export function parseTunnelConfig(
   if (responseJson.prefix) {
     (transport as {prefix?: string}).prefix = responseJson.prefix;
   }
-  return {transport};
+  return {
+    transport,
+    firstHop: getAddressFromTransportConfig(transport),
+  };
 }
 
 /** Parses an access key string into a TunnelConfig object. */
-export function staticKeyToTunnelConfig(staticKey: string): TunnelConfigJson {
-  try {
-    const config = SHADOWSOCKS_URI.parse(staticKey);
-    const transport: TransportConfigJson = {
-      host: config.host.data,
-      port: config.port.data,
-      method: config.method.data,
-      password: config.password.data,
-    };
-    if (config.extra?.['prefix']) {
-      (transport as {prefix?: string}).prefix = config.extra?.['prefix'];
-    }
-    return {transport};
-  } catch (cause) {
-    throw new errors.ServerAccessKeyInvalid('Invalid static access key.', {
-      cause,
-    });
-  }
-}
-
-export function validateAccessKey(accessKey: string) {
-  if (!isDynamicAccessKey(accessKey)) {
-    return validateStaticKey(accessKey);
-  }
-
-  try {
-    // URL does not parse the hostname if the protocol is non-standard (e.g. non-http)
-    new URL(accessKey.replace(/^ssconf:\/\//, 'https://'));
-  } catch (error) {
-    throw new errors.ServerUrlInvalid(error.message);
-  }
-}
-
-function validateStaticKey(staticKey: string) {
-  let config = null;
-  try {
-    config = SHADOWSOCKS_URI.parse(staticKey);
-  } catch (error) {
-    throw new errors.ServerUrlInvalid(
-      error.message || 'failed to parse access key'
-    );
-  }
+function staticKeyToTunnelConfig(staticKey: string): TunnelConfigJson {
+  const config = SHADOWSOCKS_URI.parse(staticKey);
   if (!isShadowsocksCipherSupported(config.method.data)) {
     throw new errors.ShadowsocksUnsupportedCipher(
       config.method.data || 'unknown'
     );
   }
+  const transport: TransportConfigJson = {
+    host: config.host.data,
+    port: config.port.data,
+    method: config.method.data,
+    password: config.password.data,
+  };
+  if (config.extra?.['prefix']) {
+    (transport as {prefix?: string}).prefix = config.extra?.['prefix'];
+  }
+  return {
+    transport,
+    firstHop: getAddressFromTransportConfig(transport),
+  };
+}
+
+export function parseAccessKey(accessKey: string): ServiceConfig {
+  try {
+    accessKey = accessKey.trim();
+
+    // The default service name is extracted from the URL fragment of the access key.
+    const name = serviceNameFromAccessKey(accessKey);
+
+    // Static ss:// keys. It encodes the full service config.
+    if (accessKey.startsWith('ss://')) {
+      return new StaticServiceConfig(name, parseTunnelConfig(accessKey));
+    }
+
+    // Dynamic ssconf:// keys. It encodes the location of the service config.
+    if (accessKey.startsWith('ssconf://') || accessKey.startsWith('https://')) {
+      try {
+        // URL does not parse the hostname (treats as opaque string) if the protocol is non-standard (e.g. non-http).
+        const configLocation = new URL(
+          accessKey.replace(/^ssconf:\/\//, 'https://')
+        );
+        return new DynamicServiceConfig(name, configLocation);
+      } catch (error) {
+        throw new errors.ServerUrlInvalid(error.message);
+      }
+    }
+
+    throw new TypeError('Access Key is not a ss:// or ssconf:// URL');
+  } catch (e) {
+    throw new errors.ServerAccessKeyInvalid('Invalid static access key.', {
+      cause: e,
+    });
+  }
+}
+
+export function validateAccessKey(accessKey: string) {
+  parseAccessKey(accessKey);
 }
 
 // We only support AEAD ciphers for Shadowsocks.
@@ -165,21 +198,13 @@ function isShadowsocksCipherSupported(cipher?: string): boolean {
   return SUPPORTED_SHADOWSOCKS_CIPHERS.includes(cipher);
 }
 
-// TODO(daniellacosse): write unit tests for these functions
-// Determines if the key is expected to be a url pointing to an ephemeral session config.
-export function isDynamicAccessKey(accessKey: string): boolean {
-  return accessKey.startsWith('ssconf://') || accessKey.startsWith('https://');
-}
-
 /**
  * serviceNameFromAccessKey extracts the service name from the access key.
  * This is done by getting parsing the fragment hash in the URL and returning the
  * entry that is not a key=value pair.
  * This is used to name the service card in the UI when the service is added.
  */
-export function serviceNameFromAccessKey(
-  accessKey: string
-): string | undefined {
+function serviceNameFromAccessKey(accessKey: string): string | undefined {
   const {hash} = new URL(accessKey.replace(/^ss(?:conf)?:\/\//, 'https://'));
 
   if (!hash) return;

--- a/client/src/www/app/outline_server_repository/config.ts
+++ b/client/src/www/app/outline_server_repository/config.ts
@@ -26,10 +26,7 @@ export type ServiceConfig = {
 } & (StaticServiceConfig | DynamicServiceConfig);
 
 export class StaticServiceConfig {
-  constructor(
-    readonly name: string,
-    readonly tunnelconfig: TunnelConfigJson
-  ) {}
+  constructor(readonly name: string, readonly tunnelConfig: TunnelConfigJson) {}
 }
 
 export class DynamicServiceConfig {

--- a/client/src/www/app/outline_server_repository/config.ts
+++ b/client/src/www/app/outline_server_repository/config.ts
@@ -32,7 +32,10 @@ export type ServiceConfig = StaticServiceConfig | DynamicServiceConfig;
  * It's the structured representation of a Static Access Key.
  */
 export class StaticServiceConfig {
-  constructor(readonly name: string, readonly tunnelConfig: TunnelConfigJson) {}
+  constructor(
+    readonly name: string,
+    readonly tunnelConfig: TunnelConfigJson
+  ) {}
 }
 
 /**
@@ -40,7 +43,10 @@ export class StaticServiceConfig {
  * It's the structured representation of a Dynamic Access Key.
  */
 export class DynamicServiceConfig {
-  constructor(readonly name: string, readonly transportConfigLocation: URL) {}
+  constructor(
+    readonly name: string,
+    readonly transportConfigLocation: URL
+  ) {}
 }
 
 /** EndpointAddress represents the address of a TCP/UDP endpoint. */

--- a/client/src/www/app/outline_server_repository/config.ts
+++ b/client/src/www/app/outline_server_repository/config.ts
@@ -21,14 +21,26 @@ export const TEST_ONLY = {
   serviceNameFromAccessKey: serviceNameFromAccessKey,
 };
 
+/**
+ * ServiceConfig represents an Outline service. It's the structured representation of an Access Key.
+ * It has a name, a tunnel config that can be statically or dynamically defined.
+ */
 export type ServiceConfig = {
   readonly name: string;
 } & (StaticServiceConfig | DynamicServiceConfig);
 
+/** 
+ * StaticServiceConfig is a ServiceConfig with a static tunnel config.
+ * It's the structured representation of a Static Access Key.
+ */
 export class StaticServiceConfig {
   constructor(readonly name: string, readonly tunnelConfig: TunnelConfigJson) {}
 }
 
+/** 
+ * DynamicServiceConfig is a ServiceConfig that has the location to fetch the tunnel config.
+ * It's the structured representation of a Dynamic Access Key.
+ */
 export class DynamicServiceConfig {
   constructor(
     readonly name: string,
@@ -36,21 +48,28 @@ export class DynamicServiceConfig {
   ) {}
 }
 
+/** EndpointAddress represents the address of a TCP/UDP endpoint. */
 class EndpointAddress {
   readonly host: string;
   readonly port: number | undefined;
 }
 
-// Transport configuration. Application code should treat it as opaque, as it's handled by the networking layer.
-export type TransportConfigJson = object;
-
-/** TunnelConfigJson represents the configuration to set up a tunnel. */
+/**
+ * TunnelConfigJson represents the configuration to set up a tunnel.
+ * This is where VPN-layer parameters would go (e.g. interface IP, routes, dns, etc.).
+ */
 export interface TunnelConfigJson {
   firstHop: EndpointAddress | undefined;
   /** transport describes how to establish connections to the destinations.
    * See https://github.com/Jigsaw-Code/outline-apps/blob/master/client/go/outline/config.go for format. */
   transport: TransportConfigJson;
 }
+
+/**
+ * TransportConfigJson represents the transport to be used.
+ * Application code should treat it as opaque, as it's handled by the networking layer.
+ */
+export type TransportConfigJson = object;
 
 /**
  * getAddressFromTransportConfig returns the address of the tunnel server, if there's a meaningful one.

--- a/client/src/www/app/outline_server_repository/outline_server_repository.spec.ts
+++ b/client/src/www/app/outline_server_repository/outline_server_repository.spec.ts
@@ -25,6 +25,7 @@ import * as config from './config';
 import {OutlineServer} from './server';
 import {FakeVpnApi} from './vpn.fake';
 import {
+  ServerAccessKeyInvalid,
   ServerUrlInvalid,
   ShadowsocksUnsupportedCipher,
 } from '../../model/errors';
@@ -193,8 +194,8 @@ describe('OutlineServerRepository', () => {
 
   it('add throws on invalid access keys', () => {
     const repo = newTestRepo(new EventQueue(), new InMemoryStorage());
-    expect(() => repo.add('ss://invalid')).toThrowError(ServerUrlInvalid);
-    expect(() => repo.add('')).toThrowError(ServerUrlInvalid);
+    expect(() => repo.add('ss://invalid')).toThrowError(ServerAccessKeyInvalid);
+    expect(() => repo.add('')).toThrowError(ServerAccessKeyInvalid);
   });
 
   it('getAll returns added servers', () => {
@@ -220,9 +221,9 @@ describe('OutlineServerRepository', () => {
     repo.add(accessKey);
     const serverId = repo.getAll()[0].id;
     const server = repo.getById(serverId);
-    expect(server.id).toEqual(serverId);
-    expect(server.accessKey).toEqual(accessKey);
-    expect(server.name).toEqual(CONFIG_0_V0.name);
+    expect(server?.id).toEqual(serverId);
+    expect(server?.accessKey).toEqual(accessKey);
+    expect(server?.name).toEqual(CONFIG_0_V0.name);
   });
 
   it('getById returns undefined for nonexistent servers', () => {
@@ -308,7 +309,7 @@ describe('OutlineServerRepository', () => {
     repo.forget(forgottenServerId);
     repo.undoForget(forgottenServerId);
     const forgottenServer = repo.getById(forgottenServerId);
-    expect(forgottenServer.id).toEqual(forgottenServerId);
+    expect(forgottenServer?.id).toEqual(forgottenServerId);
     const serverIds = repo.getAll().map(s => s.id);
     expect(serverIds.length).toEqual(2);
     expect(serverIds).toContain(forgottenServerId);
@@ -341,9 +342,11 @@ describe('OutlineServerRepository', () => {
 
   it('validates static access keys', () => {
     // Invalid access keys.
-    expect(() => config.validateAccessKey('')).toThrowError(ServerUrlInvalid);
+    expect(() => config.validateAccessKey('')).toThrowError(
+      ServerAccessKeyInvalid
+    );
     expect(() => config.validateAccessKey('ss://invalid')).toThrowError(
-      ServerUrlInvalid
+      ServerAccessKeyInvalid
     );
     // IPv6 host.
     expect(() =>
@@ -370,7 +373,7 @@ describe('OutlineServerRepository', () => {
           })
         )
       )
-    ).toThrowError(ShadowsocksUnsupportedCipher);
+    ).toThrowError(ServerAccessKeyInvalid);
     expect(() =>
       config.validateAccessKey(
         SIP002_URI.stringify(
@@ -382,7 +385,7 @@ describe('OutlineServerRepository', () => {
           })
         )
       )
-    ).toThrowError(ShadowsocksUnsupportedCipher);
+    ).toThrowError(ServerAccessKeyInvalid);
   });
 });
 

--- a/client/src/www/app/outline_server_repository/outline_server_repository.spec.ts
+++ b/client/src/www/app/outline_server_repository/outline_server_repository.spec.ts
@@ -24,11 +24,7 @@ import {
 import * as config from './config';
 import {OutlineServer} from './server';
 import {FakeVpnApi} from './vpn.fake';
-import {
-  ServerAccessKeyInvalid,
-  ServerUrlInvalid,
-  ShadowsocksUnsupportedCipher,
-} from '../../model/errors';
+import {ServerAccessKeyInvalid} from '../../model/errors';
 import {
   EventQueue,
   ServerAdded,

--- a/client/src/www/app/outline_server_repository/server.ts
+++ b/client/src/www/app/outline_server_repository/server.ts
@@ -53,7 +53,7 @@ export class OutlineServer implements Server {
       this.tunnelConfigLocation = serviceConfig.transportConfigLocation;
       this.displayAddress = '';
 
-      if (!serviceConfig.name) {
+      if (!this.name) {
         this.name =
           this.tunnelConfigLocation.port === '443'
             ? this.tunnelConfigLocation.hostname

--- a/client/src/www/app/outline_server_repository/server.ts
+++ b/client/src/www/app/outline_server_repository/server.ts
@@ -16,10 +16,11 @@ import {Localizer} from '@outline/infrastructure/i18n';
 import * as net from '@outline/infrastructure/net';
 
 import {
-  staticKeyToTunnelConfig,
   parseTunnelConfig,
-  getAddressFromTransportConfig,
   TunnelConfigJson,
+  DynamicServiceConfig,
+  StaticServiceConfig,
+  parseAccessKey,
 } from './config';
 import {StartRequestJson, VpnApi} from './vpn';
 import * as errors from '../../model/errors';
@@ -30,10 +31,11 @@ import {ResourceFetcher} from '../resource_fetcher';
 // PLEASE DON'T use this class outside of this `outline_server_repository` folder!
 
 export class OutlineServer implements Server {
-  errorMessageId?: string;
+  public readonly type: ServerType;
   readonly tunnelConfigLocation: URL;
-  private _address: string;
+  private displayAddress: string;
   private readonly staticTunnelConfig?: TunnelConfigJson;
+  errorMessageId?: string;
 
   constructor(
     private vpnApi: VpnApi,
@@ -41,47 +43,46 @@ export class OutlineServer implements Server {
     readonly id: string,
     public name: string,
     readonly accessKey: string,
-    readonly type: ServerType,
     localize: Localizer
   ) {
-    switch (this.type) {
-      case ServerType.DYNAMIC_CONNECTION:
-        this.tunnelConfigLocation = new URL(
-          accessKey.replace(/^ssconf:\/\//, 'https://')
+    const serviceConfig = parseAccessKey(accessKey);
+    this.name = name ?? serviceConfig.name;
+
+    if (serviceConfig instanceof DynamicServiceConfig) {
+      this.type = ServerType.DYNAMIC_CONNECTION;
+      this.tunnelConfigLocation = serviceConfig.transportConfigLocation;
+      this.displayAddress = '';
+
+      if (!serviceConfig.name) {
+        this.name =
+          this.tunnelConfigLocation.port === '443'
+            ? this.tunnelConfigLocation.hostname
+            : net.joinHostPort(
+                this.tunnelConfigLocation.hostname,
+                this.tunnelConfigLocation.port
+              );
+      }
+    } else if (serviceConfig instanceof StaticServiceConfig) {
+      this.type = ServerType.STATIC_CONNECTION;
+      this.staticTunnelConfig = serviceConfig.tunnelconfig;
+      const firstHop = serviceConfig.tunnelconfig.firstHop;
+      this.displayAddress = net.joinHostPort(
+        firstHop.host,
+        firstHop.port.toString()
+      );
+
+      if (!this.name) {
+        this.name = localize(
+          accessKey.includes('outline=1')
+            ? 'server-default-name-outline'
+            : 'server-default-name'
         );
-        this._address = '';
-
-        if (!name) {
-          this.name =
-            this.tunnelConfigLocation.port === '443'
-              ? this.tunnelConfigLocation.hostname
-              : net.joinHostPort(
-                  this.tunnelConfigLocation.hostname,
-                  this.tunnelConfigLocation.port
-                );
-        }
-        break;
-
-      case ServerType.STATIC_CONNECTION:
-      default:
-        this.staticTunnelConfig = staticKeyToTunnelConfig(accessKey);
-        this._address = getAddressFromTransportConfig(
-          this.staticTunnelConfig.transport
-        );
-
-        if (!name) {
-          this.name = localize(
-            accessKey.includes('outline=1')
-              ? 'server-default-name-outline'
-              : 'server-default-name'
-          );
-        }
-        break;
+      }
     }
   }
 
   get address() {
-    return this._address;
+    return this.displayAddress;
   }
 
   async connect() {
@@ -91,7 +92,10 @@ export class OutlineServer implements Server {
         this.urlFetcher,
         this.tunnelConfigLocation
       );
-      this._address = getAddressFromTransportConfig(tunnelConfig.transport);
+      this.displayAddress = net.joinHostPort(
+        tunnelConfig.firstHop.host,
+        tunnelConfig.firstHop.port.toString()
+      );
     } else {
       tunnelConfig = this.staticTunnelConfig;
     }
@@ -127,7 +131,7 @@ export class OutlineServer implements Server {
       await this.vpnApi.stop(this.id);
 
       if (this.type === ServerType.DYNAMIC_CONNECTION) {
-        this._address = '';
+        this.displayAddress = '';
       }
     } catch (e) {
       // All the plugins treat disconnection errors as ErrorCode.UNEXPECTED.

--- a/client/src/www/app/outline_server_repository/server.ts
+++ b/client/src/www/app/outline_server_repository/server.ts
@@ -64,8 +64,8 @@ export class OutlineServer implements Server {
       }
     } else if (serviceConfig instanceof StaticServiceConfig) {
       this.type = ServerType.STATIC_CONNECTION;
-      this.staticTunnelConfig = serviceConfig.tunnelconfig;
-      const firstHop = serviceConfig.tunnelconfig.firstHop;
+      this.staticTunnelConfig = serviceConfig.tunnelConfig;
+      const firstHop = serviceConfig.tunnelConfig.firstHop;
       this.displayAddress = net.joinHostPort(
         firstHop.host,
         firstHop.port.toString()

--- a/client/src/www/app/outline_server_repository/vpn.fake.ts
+++ b/client/src/www/app/outline_server_repository/vpn.fake.ts
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {getHostFromTransportConfig} from './config';
 import {VpnApi, TunnelStatus, StartRequestJson} from './vpn';
 import * as errors from '../../model/errors';
 
@@ -40,7 +39,7 @@ export class FakeVpnApi implements VpnApi {
       return;
     }
 
-    const host = getHostFromTransportConfig(request.config.transport);
+    const host = request.config.firstHop.host;
     if (this.playUnreachable(host)) {
       throw new errors.OutlinePluginError(errors.ErrorCode.SERVER_UNREACHABLE);
     } else if (this.playBroken(host)) {


### PR DESCRIPTION
This PR further reduces the exposed surface of the config library and the dependency of config-specific details, advancing the goal to be config agnostic and allow for new protocols, including Websocket. It follows https://github.com/Jigsaw-Code/outline-apps/pull/2265 and many other previous changes.

In this PR I introduce the concepts of Dynamic and Static `ServiceConfig`. The parsing function now returns the firstHop in the `TunnelConfigJson`.

I'm trying to minimize the number of functions we need to implement in Go. It's a huge pain to expose even a single function from Go, since it requires touching all platforms. Electron is particularly bad, as functions are implemented as binary execution in a new process.

I believe I've reached a point where I only need to implement `parseTunnelConfig` in Go:
- `parseAccessKey` is now a thin wrapper around parseTunnelConfig. It can stay that way.
- `validateAccessKey` simply calls parseAccessKey
- `getHostFromTransportConfig` is deleted
- `getAddressFromTransportConfig` is only called from the `parseTunnelConfig` call tree, so it can move to Go.
- `setTransportConfigHost` can be deleted if, for Electron, we resolve the first hop in `parseTunnelConfig`, and inject it in the returned config. Then the Electron code won't need to do the injection.

Phew! It took many attempts and iterations, but I believe this finally brings me to a place where we can move the config logic to Go!



