### PR TITLE
ci: fix Chromium sandbox issue of manager web test

### DIFF
--- a/.github/workflows/build_and_test_debug_manager.yml
+++ b/.github/workflows/build_and_test_debug_manager.yml
@@ -37,6 +37,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2.3.4
 
+      - name: Install Chromium
+        uses: browser-actions/setup-chrome@v1
+
       - name: Install Node
         uses: actions/setup-node@v3
         with:

--- a/.github/workflows/build_and_test_debug_manager.yml
+++ b/.github/workflows/build_and_test_debug_manager.yml
@@ -32,13 +32,10 @@ on:
 jobs:
   web_test:
     name: Web Test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v2.3.4
-
-      - name: Install Chromium
-        uses: browser-actions/setup-chrome@v1
 
       - name: Install Node
         uses: actions/setup-node@v3


### PR DESCRIPTION
This PR resolves the [sandbox error encountered during server manager web tests](https://github.com/Jigsaw-Code/outline-apps/actions/runs/12438976622/job/34995431528?pr=2291):

> `Cannot start ChromiumHeadless: No usable sandbox!`

This error is caused by [the more restricted unprivileged user namespaces feature](https://ubuntu.com/blog/ubuntu-23-10-restricted-unprivileged-user-namespaces) introduced in Ubuntu 23. It's a known limitation and many chromium based products (including electron) are affected by this change.

This PR switches the runner image from `ubuntu:latest` (which is Ubuntu 24) to `ubuntu:22.04`.