### PR TITLE
refactor(client): make parsing async and config an opaque string

### DIFF
--- a/client/electron/go_helpers.ts
+++ b/client/electron/go_helpers.ts
@@ -20,7 +20,6 @@
 
 import {pathToEmbeddedTun2socksBinary} from './app_paths';
 import {ChildProcessHelper} from './process';
-import {TransportConfigJson} from '../src/www/app/outline_server_repository/config';
 
 /**
  * Verifies the UDP connectivity of the server specified in `config`.
@@ -34,7 +33,7 @@ import {TransportConfigJson} from '../src/www/app/outline_server_repository/conf
  * @throws ProcessTerminatedExitCodeError if tun2socks failed to run.
  */
 export async function checkUDPConnectivity(
-  config: TransportConfigJson,
+  config: string,
   debugMode: boolean = false
 ): Promise<boolean> {
   const tun2socks = new ChildProcessHelper(pathToEmbeddedTun2socksBinary());

--- a/client/electron/go_helpers.ts
+++ b/client/electron/go_helpers.ts
@@ -42,7 +42,7 @@ export async function checkUDPConnectivity(
   console.debug('[tun2socks] - checking connectivity ...');
   const output = await tun2socks.launch([
     '-transport',
-    JSON.stringify(config),
+    config,
     '-checkConnectivity',
   ]);
 

--- a/client/electron/go_vpn_tunnel.ts
+++ b/client/electron/go_vpn_tunnel.ts
@@ -21,7 +21,6 @@ import {checkUDPConnectivity} from './go_helpers';
 import {ChildProcessHelper, ProcessTerminatedSignalError} from './process';
 import {RoutingDaemon} from './routing_service';
 import {VpnTunnel} from './vpn_tunnel';
-import {TransportConfigJson} from '../src/www/app/outline_server_repository/config';
 import {TunnelStatus} from '../src/www/app/outline_server_repository/vpn';
 
 const isLinux = platform() === 'linux';
@@ -64,7 +63,7 @@ export class GoVpnTunnel implements VpnTunnel {
 
   constructor(
     private readonly routing: RoutingDaemon,
-    readonly transportConfig: TransportConfigJson
+    readonly transportConfig: string
   ) {
     this.tun2socks = new GoTun2socks();
 
@@ -248,10 +247,7 @@ class GoTun2socks {
    * Otherwise, an error containing a JSON-formatted message will be thrown.
    * @param isUdpEnabled Indicates whether the remote Outline server supports UDP.
    */
-  async start(
-    config: TransportConfigJson,
-    isUdpEnabled: boolean
-  ): Promise<void> {
+  async start(transportConfig: string, isUdpEnabled: boolean): Promise<void> {
     // ./tun2socks.exe \
     //   -tunName outline-tap0 -tunDNS 1.1.1.1,9.9.9.9 \
     //   -tunAddr 10.0.85.2 -tunGw 10.0.85.1 -tunMask 255.255.255.0 \
@@ -263,7 +259,7 @@ class GoTun2socks {
     args.push('-tunGw', TUN2SOCKS_VIRTUAL_ROUTER_IP);
     args.push('-tunMask', TUN2SOCKS_VIRTUAL_ROUTER_NETMASK);
     args.push('-tunDNS', DNS_RESOLVERS.join(','));
-    args.push('-transport', JSON.stringify(config));
+    args.push('-transport', transportConfig);
     args.push('-logLevel', this.process.isDebugModeEnabled ? 'debug' : 'info');
     if (!isUdpEnabled) {
       args.push('-dnsFallback');

--- a/client/electron/index.ts
+++ b/client/electron/index.ts
@@ -19,6 +19,7 @@ import * as path from 'path';
 import * as process from 'process';
 import * as url from 'url';
 
+import * as net from '@outline/infrastructure/net';
 import * as Sentry from '@sentry/electron/main';
 import autoLaunch = require('auto-launch'); // tslint:disable-line
 import {
@@ -352,17 +353,18 @@ async function createVpnTunnel(
   // because startVpn will add a routing table entry that prefixed with this
   // host (e.g. "<host>/32"), therefore <host> must be an IP address.
   // TODO: make sure we resolve it in the native code
-  const host = tunnelConfig.firstHop.host;
+  const {host} = net.splitHostPort(tunnelConfig.firstHop);
   if (!host) {
     throw new errors.IllegalServerConfiguration('host is missing');
   }
   const hostIp = await lookupIp(host);
   const routing = new RoutingDaemon(hostIp || '', isAutoConnect);
   // Make sure the transport will use the IP we will allowlist.
-  const resolvedTransport =
-    config.setTransportConfigHost(tunnelConfig.transport, hostIp) ??
-    tunnelConfig.transport;
-  const tunnel = new GoVpnTunnel(routing, resolvedTransport);
+  // HACK: We do a simple string replacement in the config here. This may not always work with general configs
+  // but it works for simple configs.
+  // TODO: Remove the need to allowlisting the host IP.
+  tunnelConfig.transport = tunnelConfig.transport.replaceAll(host, hostIp);
+  const tunnel = new GoVpnTunnel(routing, tunnelConfig.transport);
   routing.onNetworkChange = tunnel.networkChanged.bind(tunnel);
   return tunnel;
 }

--- a/client/electron/index.ts
+++ b/client/electron/index.ts
@@ -371,6 +371,8 @@ async function createVpnTunnel(
 
 // Invoked by both the start-proxying event handler and auto-connect.
 async function startVpn(request: StartRequestJson, isAutoConnect: boolean) {
+  console.debug('startVpn called with request ', JSON.stringify(request));
+
   if (IS_LINUX && !process.env.APPIMAGE) {
     onVpnStatusChanged((id, status) => {
       setUiTunnelStatus(status, id);

--- a/client/electron/vpn_service.ts
+++ b/client/electron/vpn_service.ts
@@ -68,7 +68,7 @@ export async function establishVpn(request: StartRequestJson) {
     },
 
     // The actual transport config
-    transport: JSON.stringify(request.config.transport),
+    transport: request.config.transport,
   };
 
   await invokeMethod('EstablishVPN', JSON.stringify(config));

--- a/client/src/cordova/plugin/apple/src/OutlinePlugin.swift
+++ b/client/src/cordova/plugin/apple/src/OutlinePlugin.swift
@@ -154,10 +154,12 @@ class OutlinePlugin: CDVPlugin {
     DDLogInfo("Invoking Method \(methodName) with input \(input)")
     Task {
       guard let result = OutlineInvokeMethod(methodName, input) else {
+        DDLogInfo("InvokeMethod \(methodName) got nil result")
         return self.sendError("unexpected invoke error", callbackId: command.callbackId)
       }
       if result.error != nil {
         let errorJson = marshalErrorJson(error: OutlineError.platformError(result.error!))
+        DDLogInfo("InvokeMethod \(methodName) failed with error \(errorJson)")
         return self.sendError(errorJson, callbackId: command.callbackId)
       }
       DDLogInfo("InvokeMethod result: \(result.value)")

--- a/client/src/cordova/plugin/apple/src/OutlinePlugin.swift
+++ b/client/src/cordova/plugin/apple/src/OutlinePlugin.swift
@@ -154,7 +154,7 @@ class OutlinePlugin: CDVPlugin {
     DDLogInfo("Invoking Method \(methodName) with input \(input)")
     Task {
       guard let result = OutlineInvokeMethod(methodName, input) else {
-        DDLogInfo("InvokeMethod \(methodName) got nil result")
+        DDLogWarn("InvokeMethod \(methodName) got nil result")
         return self.sendError("unexpected invoke error", callbackId: command.callbackId)
       }
       if result.error != nil {

--- a/client/src/cordova/plugin/apple/src/OutlinePlugin.swift
+++ b/client/src/cordova/plugin/apple/src/OutlinePlugin.swift
@@ -151,18 +151,18 @@ class OutlinePlugin: CDVPlugin {
     guard let input = command.argument(at: 1) as? String else {
       return sendError("Missing method input", callbackId: command.callbackId)
     }
-    DDLogInfo("Invoking Method \(methodName) with input \(input)")
+    DDLogDebug("Invoking Method \(methodName) with input \(input)")
     Task {
       guard let result = OutlineInvokeMethod(methodName, input) else {
-        DDLogWarn("InvokeMethod \(methodName) got nil result")
+        DDLogDebug("InvokeMethod \(methodName) got nil result")
         return self.sendError("unexpected invoke error", callbackId: command.callbackId)
       }
       if result.error != nil {
         let errorJson = marshalErrorJson(error: OutlineError.platformError(result.error!))
-        DDLogInfo("InvokeMethod \(methodName) failed with error \(errorJson)")
+        DDLogDebug("InvokeMethod \(methodName) failed with error \(errorJson)")
         return self.sendError(errorJson, callbackId: command.callbackId)
       }
-      DDLogInfo("InvokeMethod result: \(result.value)")
+      DDLogDebug("InvokeMethod result: \(result.value)")
       self.sendSuccess(result.value, callbackId: command.callbackId)
     }
   }

--- a/client/src/www/app/main.cordova.ts
+++ b/client/src/www/app/main.cordova.ts
@@ -76,7 +76,12 @@ class CordovaErrorReporter extends SentryErrorReporter {
 
 class CordovaMethodChannel implements MethodChannel {
   invokeMethod(methodName: string, params: string): Promise<string> {
-    return pluginExecWithErrorCode('invokeMethod', methodName, params);
+    try {
+      return pluginExecWithErrorCode('invokeMethod', methodName, params);
+    } catch (e) {
+      console.debug('invokeMethod failed', methodName, e);
+      throw e;
+    }
   }
 }
 

--- a/client/src/www/app/outline_server_repository/config.spec.ts
+++ b/client/src/www/app/outline_server_repository/config.spec.ts
@@ -24,7 +24,8 @@ describe('parseTunnelConfig', () => {
       )
     ).toEqual({
       firstHop: 'example.com:443',
-      transport: '{"host":"example.com","port":443,"method":"METHOD","password":"PASSWORD"}'
+      transport:
+        '{"host":"example.com","port":443,"method":"METHOD","password":"PASSWORD"}',
     });
   });
 
@@ -35,7 +36,8 @@ describe('parseTunnelConfig', () => {
       )
     ).toEqual({
       firstHop: 'example.com:443',
-      transport: '{"host":"example.com","port":443,"method":"METHOD","password":"PASSWORD","prefix":"POST "}'
+      transport:
+        '{"host":"example.com","port":443,"method":"METHOD","password":"PASSWORD","prefix":"POST "}',
     });
   });
 
@@ -50,7 +52,8 @@ describe('parseTunnelConfig', () => {
     );
     expect(await config.parseTunnelConfig(ssUrl)).toEqual({
       firstHop: 'example.com:443',
-      transport: '{"host":"example.com","port":443,"method":"chacha20-ietf-poly1305","password":"PASSWORD"}'
+      transport:
+        '{"host":"example.com","port":443,"method":"chacha20-ietf-poly1305","password":"PASSWORD"}',
     });
   });
 
@@ -65,7 +68,8 @@ describe('parseTunnelConfig', () => {
     );
     expect(await config.parseTunnelConfig(`  ${ssUrl} \n\n\n`)).toEqual({
       firstHop: 'example.com:443',
-      transport: '{"host":"example.com","port":443,"method":"chacha20-ietf-poly1305","password":"PASSWORD"}'
+      transport:
+        '{"host":"example.com","port":443,"method":"chacha20-ietf-poly1305","password":"PASSWORD"}',
     });
   });
 });
@@ -73,12 +77,16 @@ describe('parseTunnelConfig', () => {
 describe('serviceNameFromAccessKey', () => {
   it('extracts name from ss:// key', () => {
     expect(
-      config.TEST_ONLY.serviceNameFromAccessKey(new URL('ss://anything#My%20Server'))
+      config.TEST_ONLY.serviceNameFromAccessKey(
+        new URL('ss://anything#My%20Server')
+      )
     ).toEqual('My Server');
   });
   it('extracts name from ssconf:// key', () => {
     expect(
-      config.TEST_ONLY.serviceNameFromAccessKey(new URL('ssconf://anything#My%20Server'))
+      config.TEST_ONLY.serviceNameFromAccessKey(
+        new URL('ssconf://anything#My%20Server')
+      )
     ).toEqual('My Server');
   });
   it('ignores parameters', () => {

--- a/client/src/www/app/outline_server_repository/config.ts
+++ b/client/src/www/app/outline_server_repository/config.ts
@@ -33,10 +33,7 @@ export type ServiceConfig = StaticServiceConfig | DynamicServiceConfig;
  * It's the structured representation of a Static Access Key.
  */
 export class StaticServiceConfig {
-  constructor(
-    readonly name: string,
-    readonly tunnelConfig: TunnelConfigJson
-  ) {}
+  constructor(readonly name: string, readonly tunnelConfig: TunnelConfigJson) {}
 }
 
 /**
@@ -44,10 +41,7 @@ export class StaticServiceConfig {
  * It's the structured representation of a Dynamic Access Key.
  */
 export class DynamicServiceConfig {
-  constructor(
-    readonly name: string,
-    readonly transportConfigLocation: URL
-  ) {}
+  constructor(readonly name: string, readonly transportConfigLocation: URL) {}
 }
 
 /**
@@ -103,7 +97,9 @@ export async function parseTunnelConfig(
 }
 
 /** Parses an access key string into a TunnelConfig object. */
-async function staticKeyToTunnelConfig(staticKey: string): Promise<TunnelConfigJson | null> {
+async function staticKeyToTunnelConfig(
+  staticKey: string
+): Promise<TunnelConfigJson | null> {
   const config = SHADOWSOCKS_URI.parse(staticKey);
   if (!isShadowsocksCipherSupported(config.method.data)) {
     throw new errors.ShadowsocksUnsupportedCipher(

--- a/client/src/www/app/outline_server_repository/config.ts
+++ b/client/src/www/app/outline_server_repository/config.ts
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {SHADOWSOCKS_URI} from 'ShadowsocksConfig';
 import * as net from '@outline/infrastructure/net';
+import {SHADOWSOCKS_URI} from 'ShadowsocksConfig';
 
 import * as errors from '../../model/errors';
 
@@ -33,7 +33,10 @@ export type ServiceConfig = StaticServiceConfig | DynamicServiceConfig;
  * It's the structured representation of a Static Access Key.
  */
 export class StaticServiceConfig {
-  constructor(readonly name: string, readonly tunnelConfig: TunnelConfigJson) {}
+  constructor(
+    readonly name: string,
+    readonly tunnelConfig: TunnelConfigJson
+  ) {}
 }
 
 /**
@@ -41,7 +44,10 @@ export class StaticServiceConfig {
  * It's the structured representation of a Dynamic Access Key.
  */
 export class DynamicServiceConfig {
-  constructor(readonly name: string, readonly transportConfigLocation: URL) {}
+  constructor(
+    readonly name: string,
+    readonly transportConfigLocation: URL
+  ) {}
 }
 
 /**

--- a/client/src/www/app/outline_server_repository/config.ts
+++ b/client/src/www/app/outline_server_repository/config.ts
@@ -13,11 +13,12 @@
 // limitations under the License.
 
 import {SHADOWSOCKS_URI} from 'ShadowsocksConfig';
+import * as net from '@outline/infrastructure/net';
 
 import * as errors from '../../model/errors';
 
 export const TEST_ONLY = {
-  getAddressFromTransportConfig: getAddressFromTransportConfig,
+  parseAccessKey: parseAccessKey,
   serviceNameFromAccessKey: serviceNameFromAccessKey,
 };
 
@@ -49,58 +50,15 @@ export class DynamicServiceConfig {
   ) {}
 }
 
-/** EndpointAddress represents the address of a TCP/UDP endpoint. */
-class EndpointAddress {
-  readonly host: string;
-  readonly port: number | undefined;
-}
-
 /**
  * TunnelConfigJson represents the configuration to set up a tunnel.
  * This is where VPN-layer parameters would go (e.g. interface IP, routes, dns, etc.).
  */
 export interface TunnelConfigJson {
-  firstHop: EndpointAddress | undefined;
+  firstHop: string;
   /** transport describes how to establish connections to the destinations.
    * See https://github.com/Jigsaw-Code/outline-apps/blob/master/client/go/outline/config.go for format. */
-  transport: TransportConfigJson;
-}
-
-/**
- * TransportConfigJson represents the transport to be used.
- * Application code should treat it as opaque, as it's handled by the networking layer.
- */
-export type TransportConfigJson = object;
-
-/**
- * getAddressFromTransportConfig returns the address of the tunnel server, if there's a meaningful one.
- * This is used to show the server address in the UI when connected.
- */
-function getAddressFromTransportConfig(
-  transport: TransportConfigJson
-): EndpointAddress | undefined {
-  const hostConfig: {host?: string; port?: number} = transport;
-  if (hostConfig.host) {
-    return {host: hostConfig.host, port: hostConfig?.port};
-  } else {
-    return undefined;
-  }
-}
-
-/**
- * setTransportConfigHost returns a new TransportConfigJson with the given host as the tunnel server.
- * Should only be set if getHostFromTransportConfig returns one.
- * This is used by the proxy resolution in Electron.
- */
-// TODO(fortuna): Move config parsing to Go and do the DNS resolution and IP injection for Electron there.
-export function setTransportConfigHost(
-  transport: TransportConfigJson,
-  newHost: string
-): TransportConfigJson | undefined {
-  if (!('host' in transport)) {
-    return undefined;
-  }
-  return {...transport, host: newHost};
+  transport: string;
 }
 
 /**
@@ -109,9 +67,9 @@ export function setTransportConfigHost(
  * This is used by the server to parse the config fetched from the dynamic key, and to parse
  * static keys as tunnel configs (which may be present in the dynamic config).
  */
-export function parseTunnelConfig(
+export async function parseTunnelConfig(
   tunnelConfigText: string
-): TunnelConfigJson | null {
+): Promise<TunnelConfigJson | null> {
   tunnelConfigText = tunnelConfigText.trim();
   if (tunnelConfigText.startsWith('ss://')) {
     return staticKeyToTunnelConfig(tunnelConfigText);
@@ -129,7 +87,7 @@ export function parseTunnelConfig(
   // TODO(fortuna): stop converting to the Go format. Let the Go code convert.
   // We don't validate the method because that's already done in the Go code as
   // part of the Dynamic Key connection flow.
-  const transport: TransportConfigJson = {
+  const transport = {
     host: responseJson.server,
     port: responseJson.server_port,
     method: responseJson.method,
@@ -139,20 +97,20 @@ export function parseTunnelConfig(
     (transport as {prefix?: string}).prefix = responseJson.prefix;
   }
   return {
-    transport,
-    firstHop: getAddressFromTransportConfig(transport),
+    firstHop: net.joinHostPort(transport.host, `${transport.port}`),
+    transport: JSON.stringify(transport),
   };
 }
 
 /** Parses an access key string into a TunnelConfig object. */
-function staticKeyToTunnelConfig(staticKey: string): TunnelConfigJson {
+async function staticKeyToTunnelConfig(staticKey: string): Promise<TunnelConfigJson | null> {
   const config = SHADOWSOCKS_URI.parse(staticKey);
   if (!isShadowsocksCipherSupported(config.method.data)) {
     throw new errors.ShadowsocksUnsupportedCipher(
       config.method.data || 'unknown'
     );
   }
-  const transport: TransportConfigJson = {
+  const transport = {
     host: config.host.data,
     port: config.port.data,
     method: config.method.data,
@@ -162,29 +120,40 @@ function staticKeyToTunnelConfig(staticKey: string): TunnelConfigJson {
     (transport as {prefix?: string}).prefix = config.extra?.['prefix'];
   }
   return {
-    transport,
-    firstHop: getAddressFromTransportConfig(transport),
+    firstHop: net.joinHostPort(transport.host, `${transport.port}`),
+    transport: JSON.stringify(transport),
   };
 }
 
-export function parseAccessKey(accessKey: string): ServiceConfig {
+export async function parseAccessKey(
+  accessKeyText: string
+): Promise<ServiceConfig> {
   try {
-    accessKey = accessKey.trim();
+    const accessKeyUrl = new URL(accessKeyText.trim());
 
     // The default service name is extracted from the URL fragment of the access key.
-    const name = serviceNameFromAccessKey(accessKey);
+    const name = serviceNameFromAccessKey(accessKeyUrl);
+    // The hash only encodes service config, not tunnel config or config location.
+    const noHashAccessKey = new URL(accessKeyUrl);
+    noHashAccessKey.hash = '';
 
     // Static ss:// keys. It encodes the full service config.
-    if (accessKey.startsWith('ss://')) {
-      return new StaticServiceConfig(name, parseTunnelConfig(accessKey));
+    if (noHashAccessKey.protocol === 'ss:') {
+      return new StaticServiceConfig(
+        name,
+        await parseTunnelConfig(noHashAccessKey.toString())
+      );
     }
 
     // Dynamic ssconf:// keys. It encodes the location of the service config.
-    if (accessKey.startsWith('ssconf://') || accessKey.startsWith('https://')) {
+    if (
+      noHashAccessKey.protocol === 'ssconf:' ||
+      noHashAccessKey.protocol === 'https:'
+    ) {
       try {
         // URL does not parse the hostname (treats as opaque string) if the protocol is non-standard (e.g. non-http).
         const configLocation = new URL(
-          accessKey.replace(/^ssconf:\/\//, 'https://')
+          noHashAccessKey.toString().replace(/^ssconf:\/\//, 'https://')
         );
         return new DynamicServiceConfig(name, configLocation);
       } catch (error) {
@@ -198,10 +167,6 @@ export function parseAccessKey(accessKey: string): ServiceConfig {
       cause: e,
     });
   }
-}
-
-export function validateAccessKey(accessKey: string) {
-  parseAccessKey(accessKey);
 }
 
 // We only support AEAD ciphers for Shadowsocks.
@@ -223,13 +188,11 @@ function isShadowsocksCipherSupported(cipher?: string): boolean {
  * entry that is not a key=value pair.
  * This is used to name the service card in the UI when the service is added.
  */
-function serviceNameFromAccessKey(accessKey: string): string | undefined {
-  const {hash} = new URL(accessKey.replace(/^ss(?:conf)?:\/\//, 'https://'));
-
-  if (!hash) return;
+function serviceNameFromAccessKey(accessKey: URL): string | undefined {
+  if (!accessKey.hash) return;
 
   return decodeURIComponent(
-    hash
+    accessKey.hash
       .slice(1)
       .split('&')
       .find(keyValuePair => !keyValuePair.includes('='))

--- a/client/src/www/app/outline_server_repository/index.ts
+++ b/client/src/www/app/outline_server_repository/index.ts
@@ -131,7 +131,7 @@ class OutlineServerRepository implements ServerRepository {
   ) {}
 
   getAll() {
-    return Array.from(this.serverById.values()).map(e => e.server);
+    return Array.from(this.serverById.values(), e => e.server);
   }
 
   getById(serverId: string) {
@@ -154,7 +154,7 @@ class OutlineServerRepository implements ServerRepository {
   }
 
   rename(serverId: string, newName: string) {
-    const server = this.serverById.get(serverId)?.server;
+    const server = this.getById(serverId);
     if (!server) {
       console.warn(`Cannot rename nonexistent server ${serverId}`);
       return;

--- a/client/src/www/app/outline_server_repository/server.ts
+++ b/client/src/www/app/outline_server_repository/server.ts
@@ -34,7 +34,7 @@ import {getDefaultMethodChannel} from '../method_channel';
 export async function newOutlineServer(
   vpnApi: VpnApi,
   id: string,
-  name?: string,
+  name: string | undefined,
   accessKey: string,
   localize: Localizer
 ): Promise<Server> {

--- a/client/src/www/app/outline_server_repository/server.ts
+++ b/client/src/www/app/outline_server_repository/server.ts
@@ -34,7 +34,7 @@ import {getDefaultMethodChannel} from '../method_channel';
 export async function newOutlineServer(
   vpnApi: VpnApi,
   id: string,
-  name: string,
+  name?: string,
   accessKey: string,
   localize: Localizer
 ): Promise<Server> {
@@ -62,14 +62,13 @@ export async function newOutlineServer(
           : 'server-default-name'
       );
     }
-    const server = new OutlineServer(vpnApi, id, name, serviceConfig);
-    return server;
+    return new OutlineServer(vpnApi, id, name, serviceConfig);
   }
 }
 
 class OutlineServer implements Server {
   errorMessageId?: string;
-  private tunnelConfig: TunnelConfigJson | undefined;
+  private tunnelConfig?: TunnelConfigJson;
 
   constructor(
     private vpnApi: VpnApi,

--- a/client/src/www/app/outline_server_repository/vpn.cordova.ts
+++ b/client/src/www/app/outline_server_repository/vpn.cordova.ts
@@ -28,7 +28,7 @@ export class CordovaVpnApi implements VpnApi {
       // TODO(fortuna): Make the Cordova plugin take a StartRequestJson.
       request.id,
       request.name,
-      JSON.stringify(request.config.transport)
+      request.config.transport
     );
   }
 

--- a/client/src/www/app/outline_server_repository/vpn.fake.ts
+++ b/client/src/www/app/outline_server_repository/vpn.fake.ts
@@ -26,12 +26,12 @@ export class FakeVpnApi implements VpnApi {
 
   constructor() {}
 
-  private playBroken(hostname?: string) {
-    return hostname === FAKE_BROKEN_HOSTNAME;
+  private playBroken(address?: string) {
+    return address.startsWith(FAKE_BROKEN_HOSTNAME);
   }
 
-  private playUnreachable(hostname?: string) {
-    return hostname === FAKE_UNREACHABLE_HOSTNAME;
+  private playUnreachable(address?: string) {
+    return address.startsWith(FAKE_UNREACHABLE_HOSTNAME);
   }
 
   async start(request: StartRequestJson): Promise<void> {
@@ -39,10 +39,10 @@ export class FakeVpnApi implements VpnApi {
       return;
     }
 
-    const host = request.config.firstHop.host;
-    if (this.playUnreachable(host)) {
+    const address = request.config.firstHop;
+    if (this.playUnreachable(address)) {
       throw new errors.OutlinePluginError(errors.ErrorCode.SERVER_UNREACHABLE);
-    } else if (this.playBroken(host)) {
+    } else if (this.playBroken(address)) {
       throw new errors.OutlinePluginError(
         errors.ErrorCode.CLIENT_START_FAILURE
       );

--- a/client/src/www/app/outline_server_repository/vpn.fake.ts
+++ b/client/src/www/app/outline_server_repository/vpn.fake.ts
@@ -27,11 +27,11 @@ export class FakeVpnApi implements VpnApi {
   constructor() {}
 
   private playBroken(address?: string) {
-    return address.startsWith(FAKE_BROKEN_HOSTNAME);
+    return address?.startsWith(FAKE_BROKEN_HOSTNAME);
   }
 
   private playUnreachable(address?: string) {
-    return address.startsWith(FAKE_UNREACHABLE_HOSTNAME);
+    return address?.startsWith(FAKE_UNREACHABLE_HOSTNAME);
   }
 
   async start(request: StartRequestJson): Promise<void> {

--- a/client/src/www/model/server.ts
+++ b/client/src/www/model/server.ts
@@ -14,22 +14,10 @@
 
 // TODO: add guidelines for this file
 
-export enum ServerType {
-  // The connection data is static, doesn't change, and isn't deleted on disconnect.
-  STATIC_CONNECTION,
-
-  // The connection data is refetched via the access key on each connection.
-  // and deleted on each disconnection
-  DYNAMIC_CONNECTION,
-}
-
 // TODO(daniellacosse): determine what properties should be controlled only by the Server implementation and make them readonly
 export interface Server {
   // A unique id that identifies this Server.
   readonly id: string;
-
-  // A type specifying the manner in which the Server connects.
-  readonly type: ServerType;
 
   // The name of this server, as given by the user.
   name: string;
@@ -55,7 +43,8 @@ export interface Server {
 }
 
 export interface ServerRepository {
-  add(accessKey: string): void;
+  add(accessKey: string): Promise<void>;
+  rename(serverId: string, name: string): void;
   forget(serverId: string): void;
   undoForget(serverId: string): void;
   getAll(): Server[];

--- a/client/src/www/views/contact_view/support_form/index.spec.ts
+++ b/client/src/www/views/contact_view/support_form/index.spec.ts
@@ -16,10 +16,16 @@
 
 import {TextField} from '@material/mwc-textfield';
 
-import {fixture, html, nextFrame, oneEvent, triggerBlurFor, triggerFocusFor} from '@open-wc/testing';
+import {
+  fixture,
+  html,
+  nextFrame,
+  oneEvent,
+  triggerBlurFor,
+  triggerFocusFor,
+} from '@open-wc/testing';
 
 import {FormValues, SupportForm} from './index';
-
 
 async function setValue(el: TextField, value: string) {
   await triggerFocusFor(el);
@@ -40,22 +46,37 @@ describe('SupportForm', () => {
       accessKeySource: 'a friend',
       subject: 'Test Subject',
       description: 'Test Description',
+      outreachConsent: false,
     };
-    const el = await fixture(html` <support-form .values=${values}></support-form> `);
+    const el = await fixture(html`
+      <support-form .values=${values}></support-form>
+    `);
 
-    const emailInput: TextField = el.shadowRoot!.querySelector('mwc-textfield[name="email"')!;
+    const emailInput: TextField = el.shadowRoot!.querySelector(
+      'mwc-textfield[name="email"'
+    )!;
     expect(emailInput.value).toBe('foo@bar.com');
-    const accessKeySourceInput: TextField = el.shadowRoot!.querySelector('mwc-textfield[name="accessKeySource"')!;
+    const accessKeySourceInput: TextField = el.shadowRoot!.querySelector(
+      'mwc-textfield[name="accessKeySource"'
+    )!;
     expect(accessKeySourceInput.value).toBe('a friend');
-    const subjectInput: TextField = el.shadowRoot!.querySelector('mwc-textfield[name="subject"')!;
+    const subjectInput: TextField = el.shadowRoot!.querySelector(
+      'mwc-textfield[name="subject"'
+    )!;
     expect(subjectInput.value).toBe('Test Subject');
-    const descriptionInput: TextField = el.shadowRoot!.querySelector('mwc-textarea[name="description"')!;
+    const descriptionInput: TextField = el.shadowRoot!.querySelector(
+      'mwc-textarea[name="description"'
+    )!;
     expect(descriptionInput.value).toBe('Test Description');
   });
 
   it('updating the `values` property updates the form', async () => {
-    const el: SupportForm = await fixture(html` <support-form></support-form> `);
-    const emailInput: TextField = el.shadowRoot!.querySelector('mwc-textfield[name="email"')!;
+    const el: SupportForm = await fixture(html`
+      <support-form></support-form>
+    `);
+    const emailInput: TextField = el.shadowRoot!.querySelector(
+      'mwc-textfield[name="email"'
+    )!;
     await setValue(emailInput, 'foo@bar.com');
 
     el.values = {};
@@ -66,7 +87,9 @@ describe('SupportForm', () => {
 
   it('submit button is disabled by default', async () => {
     const el = await fixture(html` <support-form></support-form> `);
-    const submitButton = el.shadowRoot!.querySelectorAll('mwc-button')[1] as HTMLElement;
+    const submitButton = el.shadowRoot!.querySelectorAll(
+      'mwc-button'
+    )[1] as HTMLElement;
     expect(submitButton.hasAttribute('disabled')).toBeTrue();
   });
 
@@ -77,16 +100,26 @@ describe('SupportForm', () => {
     beforeEach(async () => {
       el = await fixture(html` <support-form></support-form> `);
 
-      const emailInput: TextField = el.shadowRoot!.querySelector('mwc-textfield[name="email"')!;
+      const emailInput: TextField = el.shadowRoot!.querySelector(
+        'mwc-textfield[name="email"'
+      )!;
       await setValue(emailInput, 'foo@bar.com');
-      const accessKeySourceInput: TextField = el.shadowRoot!.querySelector('mwc-textfield[name="accessKeySource"')!;
+      const accessKeySourceInput: TextField = el.shadowRoot!.querySelector(
+        'mwc-textfield[name="accessKeySource"'
+      )!;
       await setValue(accessKeySourceInput, 'From a friend');
-      const subjectInput: TextField = el.shadowRoot!.querySelector('mwc-textfield[name="subject"')!;
+      const subjectInput: TextField = el.shadowRoot!.querySelector(
+        'mwc-textfield[name="subject"'
+      )!;
       await setValue(subjectInput, 'Test Subject');
-      const descriptionInput: TextField = el.shadowRoot!.querySelector('mwc-textarea[name="description"')!;
+      const descriptionInput: TextField = el.shadowRoot!.querySelector(
+        'mwc-textarea[name="description"'
+      )!;
       await setValue(descriptionInput, 'Test Description');
 
-      submitButton = el.shadowRoot!.querySelectorAll('mwc-button')[1] as HTMLElement;
+      submitButton = el.shadowRoot!.querySelectorAll(
+        'mwc-button'
+      )[1] as HTMLElement;
     });
 
     it('submit button is enabled', async () => {
@@ -104,10 +137,14 @@ describe('SupportForm', () => {
   });
 
   it('emits form cancel event', async () => {
-    const el: SupportForm = await fixture(html` <support-form></support-form> `);
+    const el: SupportForm = await fixture(html`
+      <support-form></support-form>
+    `);
     const listener = oneEvent(el, 'cancel');
 
-    const cancelButton = el.shadowRoot!.querySelectorAll('mwc-button')[0] as HTMLElement;
+    const cancelButton = el.shadowRoot!.querySelectorAll(
+      'mwc-button'
+    )[0] as HTMLElement;
     cancelButton.click();
 
     const {detail} = await listener;

--- a/client/src/www/views/root_view/add_access_key_dialog/index.ts
+++ b/client/src/www/views/root_view/add_access_key_dialog/index.ts
@@ -22,7 +22,10 @@ export class AddAccessKeyDialog extends LitElement {
   ) => string;
   @property({type: Boolean}) open: boolean;
   @property({type: String}) accessKey: string = '';
-  @property({type: Function}) isValidAccessKey: (accessKey: string) => boolean;
+  @property({type: Boolean}) isValidAccessKey: boolean = false;
+  @property({type: Function}) validateAccessKey: (
+    accessKey: string
+  ) => Promise<boolean>;
 
   static styles = css`
     :host {
@@ -89,7 +92,11 @@ export class AddAccessKeyDialog extends LitElement {
         ></section>
         <section>
           <md-filled-text-field
-            .error=${this.accessKey && !this.isValidAccessKey(this.accessKey)}
+            .error=${this.accessKey && !this.isValidAccessKey}
+            @change=${this.updateIsValidAccessKey(
+              this.accessKey,
+              this.validateAccessKey
+            )}
             @input=${this.handleEdit}
             error-text="${this.localize('add-access-key-dialog-error-text')}"
             label="${this.localize('add-access-key-dialog-label')}"
@@ -105,11 +112,20 @@ export class AddAccessKeyDialog extends LitElement {
         </md-text-button>
         <md-filled-button
           @click=${this.handleConfirm}
-          ?disabled=${!this.accessKey || !this.isValidAccessKey(this.accessKey)}
+          ?disabled=${!this.accessKey || !this.isValidAccessKey}
           >${this.localize('confirm')}</md-filled-button
         >
       </fieldset>
     </md-dialog>`;
+  }
+
+  private updateIsValidAccessKey(
+    accessKey: string,
+    validate: (accessKey: string) => Promise<boolean>
+  ) {
+    validate(accessKey).then(result => {
+      this.isValidAccessKey = result;
+    });
   }
 
   private handleEdit(event: InputEvent) {

--- a/client/src/www/views/root_view/add_access_key_dialog/index.ts
+++ b/client/src/www/views/root_view/add_access_key_dialog/index.ts
@@ -123,6 +123,7 @@ export class AddAccessKeyDialog extends LitElement {
     accessKey: string,
     validate: (accessKey: string) => Promise<boolean>
   ) {
+    this.isValidAccessKey = false;
     validate(accessKey).then(result => {
       this.isValidAccessKey = result;
     });

--- a/infrastructure/net.spec.ts
+++ b/infrastructure/net.spec.ts
@@ -22,3 +22,36 @@ describe('joinHostPort', () => {
     expect(net.joinHostPort('8example.com', '443')).toEqual('8example.com:443');
   });
 });
+
+describe('splitHostPort', () => {
+  it('splits correctly', () => {
+    expect(net.splitHostPort('example.com:443')).toEqual({
+      host: 'example.com',
+      port: '443',
+    });
+    expect(net.splitHostPort('example.com:')).toEqual({
+      host: 'example.com',
+      port: '',
+    });
+    expect(net.splitHostPort('1.2.3.4:443')).toEqual({
+      host: '1.2.3.4',
+      port: '443',
+    });
+    expect(net.splitHostPort('1.2.3.4:')).toEqual({
+      host: '1.2.3.4',
+      port: '',
+    });
+    expect(net.splitHostPort('[1:2:3::4]:443')).toEqual({
+      host: '1:2:3::4',
+      port: '443',
+    });
+    expect(net.splitHostPort('[1:2:3::4]:')).toEqual({
+      host: '1:2:3::4',
+      port: '',
+    });
+    expect(net.splitHostPort('8example.com:443')).toEqual({
+      host: '8example.com',
+      port: '443',
+    });
+  });
+});

--- a/infrastructure/net.ts
+++ b/infrastructure/net.ts
@@ -19,3 +19,23 @@ export function joinHostPort(host: string, port: string): string {
     return `${host}:${port}`;
   }
 }
+
+export function splitHostPort(address: string): {host: string; port: string} {
+  const splitPos = address.lastIndexOf(':');
+  if (splitPos === -1) {
+    throw new Error('host:port separator not found');
+  }
+  let host = address.substring(0, splitPos);
+  if (host.length > 0 && host[0] === '[') {
+    if (host[host.length - 1] !== ']') {
+      throw new Error('IPv6 address missing closing ]');
+    }
+    host = host.substring(1, host.length - 1);
+  }
+  const port = address.substring(splitPos + 1, address.length);
+
+  return {
+    host: host,
+    port: port,
+  };
+}


### PR DESCRIPTION
This PR turns config parsing async, in preparation for parsing in the Go code. It had ripple effect all over the Typescript code.

This also changes the parsing API to output firstHop + transport, with transport being an opaque string as opposed to an object.