### PR TITLE
Change TCP test website to something reliable and often whitelisted

### DIFF
--- a/client/go/outline/connectivity/connectivity.go
+++ b/client/go/outline/connectivity/connectivity.go
@@ -33,7 +33,7 @@ const (
 )
 
 const (
-	testTCPWebsite    = "http://example.com"
+	testTCPWebsite    = "http://captive.apple.com"
 	testDNSServerIP   = "1.1.1.1"
 	testDNSServerPort = 53
 )


### PR DESCRIPTION
Issue: #2326 

Fixed by changing the test TCP website to Apple's captive portal test url (captive.apple.com).

## Background
This domain is designed to check connectivity unlike example.com, which explicitly warned not to use its domain for production purposes. (ref: https://www.iana.org/help/example-domains)

That example.com's servers failed this morning, every Outline client cannot reconnect to their VPN server unless they connected before the server failure.

The error message shown in Outline didn't help much but I tracked down and that example.com was culprit. (I cannot connect to example.com from my servers, my home networks, for about 1 hour). Every Outline users were unable to do anything, despite their VPN servers are working.


## Why captive.apple.com

It always return 200 status, even with HEAD request method.

It has got much better ping < 10ms in all over the world (because they use geo-dns) compared to example.com which is about 200ms everytime I ping from Thailand.

Will not break in anytime soon, because they are being used in every Apple devices as connectivity test, similar to Microsoft's msftconnecttest.com.