### PR TITLE
chore(client): clean up invokeMethod error propagation

### DIFF
--- a/client/electron/go_plugin.ts
+++ b/client/electron/go_plugin.ts
@@ -32,7 +32,7 @@ let invokeMethodFunc: Function | undefined;
  * Ensure that the function signature and data structures are consistent with the C definitions
  * in `./client/go/outline/electron/go_plugin.go`.
  */
-export async function invokeMethod(
+export async function invokeGoMethod(
   method: string,
   input: string
 ): Promise<string> {

--- a/client/electron/vpn_service.ts
+++ b/client/electron/vpn_service.ts
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {invokeMethod} from './go_plugin';
+import {invokeGoMethod} from './go_plugin';
 import {
   StartRequestJson,
   TunnelStatus,
@@ -71,13 +71,13 @@ export async function establishVpn(request: StartRequestJson) {
     transport: request.config.transport,
   };
 
-  await invokeMethod('EstablishVPN', JSON.stringify(config));
+  await invokeGoMethod('EstablishVPN', JSON.stringify(config));
   statusCb?.(currentRequestId, TunnelStatus.CONNECTED);
 }
 
 export async function closeVpn(): Promise<void> {
   statusCb?.(currentRequestId!, TunnelStatus.DISCONNECTING);
-  await invokeMethod('CloseVPN', '');
+  await invokeGoMethod('CloseVPN', '');
   statusCb?.(currentRequestId!, TunnelStatus.DISCONNECTED);
 }
 

--- a/client/src/www/app/main.cordova.ts
+++ b/client/src/www/app/main.cordova.ts
@@ -39,6 +39,7 @@ import {
 import {AbstractUpdater} from './updater';
 import * as interceptors from './url_interceptor';
 import {NoOpVpnInstaller, VpnInstaller} from './vpn_installer';
+import {PlatformError} from '../model/platform_error';
 import {SentryErrorReporter, Tags} from '../shared/error_reporter';
 
 const hasDeviceSupport = cordova.platformId !== 'browser';
@@ -80,7 +81,7 @@ class CordovaMethodChannel implements MethodChannel {
       return pluginExecWithErrorCode('invokeMethod', methodName, params);
     } catch (e) {
       console.debug('invokeMethod failed', methodName, e);
-      throw e;
+      throw PlatformError.parseFrom(e);
     }
   }
 }

--- a/client/src/www/app/main.electron.ts
+++ b/client/src/www/app/main.electron.ts
@@ -28,6 +28,7 @@ import {AbstractUpdater} from './updater';
 import {UrlInterceptor} from './url_interceptor';
 import {VpnInstaller} from './vpn_installer';
 import {ErrorCode, OutlinePluginError} from '../model/errors';
+import {PlatformError} from '../model/platform_error';
 import {
   getSentryBrowserIntegrations,
   OutlineErrorReporter,
@@ -129,11 +130,15 @@ class ElectronErrorReporter implements OutlineErrorReporter {
 
 class ElectronMethodChannel implements MethodChannel {
   invokeMethod(methodName: string, params: string): Promise<string> {
-    return window.electron.methodChannel.invoke(
-      'invoke-method',
-      methodName,
-      params
-    );
+    try {
+      return window.electron.methodChannel.invoke(
+        'invoke-method',
+        methodName,
+        params
+      );
+    } catch (e) {
+      throw PlatformError.parseFrom(e);
+    }
   }
 }
 

--- a/client/src/www/app/outline_server_repository/vpn.electron.ts
+++ b/client/src/www/app/outline_server_repository/vpn.electron.ts
@@ -17,7 +17,7 @@ import {IpcRendererEvent} from 'electron/main';
 import {TunnelStatus} from './vpn';
 import {StartRequestJson} from './vpn';
 import {VpnApi} from './vpn';
-import {PlatformError} from '../../model/platform_error';
+import * as methodChannel from '../method_channel';
 
 export class ElectronVpnApi implements VpnApi {
   private statusChangeListener:
@@ -54,11 +54,9 @@ export class ElectronVpnApi implements VpnApi {
       return Promise.resolve();
     }
 
-    try {
-      await window.electron.methodChannel.invoke('start-proxying', request);
-    } catch (e) {
-      throw PlatformError.parseFrom(e);
-    }
+    await methodChannel
+      .getDefaultMethodChannel()
+      .invokeMethod('StartProxying', JSON.stringify(request));
   }
 
   async stop(id: string) {
@@ -66,11 +64,9 @@ export class ElectronVpnApi implements VpnApi {
       return;
     }
 
-    try {
-      await window.electron.methodChannel.invoke('stop-proxying');
-    } catch (e) {
-      console.error(`Failed to stop tunnel ${e}`);
-    }
+    await methodChannel
+      .getDefaultMethodChannel()
+      .invokeMethod('StopProxying', '');
   }
 
   async isRunning(id: string): Promise<boolean> {


### PR DESCRIPTION
This ensures the error on invokeMethod is always parsed as a PlatformError.

This also moves StartProxying and StopPRoxying into the MethodChannel. We should not be introducing new IPCs and reuse the method channel instead.