### PR TITLE
fix(client/linux): update TUN and IP to avoid conflicts with legacy routing

### DIFF
--- a/client/electron/vpn_service.ts
+++ b/client/electron/vpn_service.ts
@@ -42,20 +42,21 @@ export async function establishVpn(request: StartRequestJson) {
   statusCb?.(currentRequestId, TunnelStatus.RECONNECTING);
 
   const config: EstablishVpnRequest = {
+    // The following VPN configuration ensures that the new routing can co-exist with any legacy Outline routings (e.g. AppImage).
     vpn: {
       id: currentRequestId,
 
-      // TUN device name, being compatible with old code:
+      // TUN device name, use 'outline-tun1' to avoid conflict with old 'outline-tun0':
       // https://github.com/Jigsaw-Code/outline-apps/blob/client/linux/v1.14.0/client/electron/linux_proxy_controller/outline_proxy_controller.h#L203
-      interfaceName: 'outline-tun0',
+      interfaceName: 'outline-tun1',
 
       // Network Manager connection name, Use "TUN Connection" instead of "VPN Connection"
       // because Network Manager has a dedicated "VPN Connection" concept that we did not implement
       connectionName: 'Outline TUN Connection',
 
-      // TUN IP, being compatible with old code:
+      // TUN IP, use '10.0.85.5' to avoid conflict with old '10.0.85.1':
       // https://github.com/Jigsaw-Code/outline-apps/blob/client/linux/v1.14.0/client/electron/linux_proxy_controller/outline_proxy_controller.h#L204
-      ipAddress: '10.0.85.1',
+      ipAddress: '10.0.85.5',
 
       // DNS server list, being compatible with old code:
       // https://github.com/Jigsaw-Code/outline-apps/blob/client/linux/v1.14.0/client/electron/linux_proxy_controller/outline_proxy_controller.h#L207

--- a/client/go/outline/vpn/vpn_linux.go
+++ b/client/go/outline/vpn/vpn_linux.go
@@ -84,7 +84,7 @@ func (c *linuxVPNConn) Establish(ctx context.Context) (err error) {
 	}
 
 	if c.tun, err = newTUNDevice(c.nmOpts.TUNName); err != nil {
-		return errSetupVPN("failed to create tun device", err, "name", c.nmOpts.Name)
+		return errSetupVPN("failed to create tun device", err, "name", c.nmOpts.TUNName)
 	}
 	slog.Info("tun device created", "name", c.nmOpts.TUNName)
 


### PR DESCRIPTION
This fix allows the `AppImage` and `.deb` to work side-by-side. It also prepares to avoid IP conflicts with OpenVPN drivers for the new Windows routing.