### PR TITLE
fix(client): enforce no proxyless

### DIFF
--- a/client/go/outline/client.go
+++ b/client/go/outline/client.go
@@ -87,5 +87,19 @@ func newClientWithBaseDialers(transportConfig string, tcpDialer transport.Stream
 		}
 	}
 
+	// Make sure the transport is not proxyless for now.
+	if transportPair.StreamDialer.ConnType == config.ConnTypeDirect {
+		return nil, &platerrors.PlatformError{
+			Code:    platerrors.InvalidConfig,
+			Message: "transport must tunnel TCP traffic",
+		}
+	}
+	if transportPair.PacketListener.ConnType == config.ConnTypeDirect {
+		return nil, &platerrors.PlatformError{
+			Code:    platerrors.InvalidConfig,
+			Message: "transport must tunnel UDP traffic",
+		}
+	}
+
 	return &Client{sd: transportPair.StreamDialer, pl: transportPair.PacketListener}, nil
 }

--- a/client/go/outline/client_test.go
+++ b/client/go/outline/client_test.go
@@ -17,6 +17,7 @@ package outline
 import (
 	"testing"
 
+	"github.com/Jigsaw-Code/outline-apps/client/go/outline/platerrors"
 	"github.com/stretchr/testify/require"
 )
 
@@ -215,6 +216,19 @@ udp:
 	require.Nil(t, result.Error, "Got %v", result.Error)
 	require.Equal(t, firstHop, result.Client.sd.FirstHop)
 	require.Equal(t, firstHop, result.Client.pl.FirstHop)
+}
+
+func Test_NewTransport_DisallowProxyless(t *testing.T) {
+	config := `
+$type: tcpudp
+tcp:
+udp:`
+	result := NewClient(config)
+	require.Error(t, result.Error, "Got %v", result.Error)
+	perr := &platerrors.PlatformError{}
+	require.ErrorAs(t, result.Error, &perr)
+	require.Equal(t, platerrors.InvalidConfig, perr.Code)
+	require.Equal(t, "transport must tunnel TCP traffic", result.Error.Message)
 }
 
 func Test_NewClientFromJSON_Errors(t *testing.T) {

--- a/client/go/outline/platerrors/platform_error.go
+++ b/client/go/outline/platerrors/platform_error.go
@@ -82,6 +82,11 @@ func (e PlatformError) Error() string {
 
 // Unwrap returns the cause of this [PlatformError].
 func (e PlatformError) Unwrap() error {
+	// Make sure we return a nil value, not an interface value with type `*PlatformError` pointing to nil.
+	// Otherwise nil equality fails and recursive unwrapping panics.
+	if e.Cause == nil {
+		return nil
+	}
 	return e.Cause
 }
 

--- a/client/go/outline/platerrors/platform_error_test.go
+++ b/client/go/outline/platerrors/platform_error_test.go
@@ -113,6 +113,11 @@ func TestPlatformErrorWrapsCause(t *testing.T) {
 	require.Nil(t, err.Unwrap())
 }
 
+func TestPlatformErrorUnrapsNil(t *testing.T) {
+	err := PlatformError{Code: InternalError, Message: "some message"}
+	require.Equal(t, nil, err.Unwrap())
+}
+
 func TestEmptyErrorCode(t *testing.T) {
 	pe := &PlatformError{}
 


### PR DESCRIPTION
This makes sure we won't accidentally allow proxyless.

Error:
<img width="372" alt="image" src="https://github.com/user-attachments/assets/b3517338-a28e-4255-a6b5-fb70b4cf5b01" />
