### PR TITLE
build(client/windows): code sign dependent binaries included in NSIS

### DIFF
--- a/client/electron/build.action.mjs
+++ b/client/electron/build.action.mjs
@@ -39,7 +39,9 @@ export async function main(...parameters) {
   }
 
   if (buildMode === 'debug') {
-    console.warn(`WARNING: building "${platform}" in [DEBUG] mode. Do not publish this build!!`);
+    console.warn(
+      `WARNING: building "${platform}" in [DEBUG] mode. Do not publish this build!!`
+    );
   }
 
   if (buildMode === 'release' && !autoUpdateUrl) {
@@ -53,10 +55,33 @@ export async function main(...parameters) {
   await runAction('client/go/build', ...parameters);
   await runAction('client/electron/build_main', ...parameters);
 
-  await fs.mkdir(path.join(getRootDir(), ELECTRON_BUILD_DIR, 'client', 'electron'), {recursive: true});
+  // Sign NSIS dependent binaries (electron won't track them)
+  if (platform === 'windows') {
+    await runAction(
+      'client/electron/windows/sign_windows_executable',
+      '--target',
+      'client/electron/windows/smartdnsblock/bin/smartdnsblock.exe',
+      '--algorithm',
+      'sha256'
+    );
+    await runAction(
+      'client/electron/windows/sign_windows_executable',
+      '--target',
+      'client/electron/windows/OutlineService/OutlineService/bin/OutlineService.exe',
+      '--algorithm',
+      'sha256'
+    );
+  }
+
+  await fs.mkdir(
+    path.join(getRootDir(), ELECTRON_BUILD_DIR, 'client', 'electron'),
+    {recursive: true}
+  );
 
   const electronConfig = JSON.parse(
-    await fs.readFile(path.resolve(getRootDir(), 'client', 'electron', 'electron-builder.json'))
+    await fs.readFile(
+      path.resolve(getRootDir(), 'client', 'electron', 'electron-builder.json')
+    )
   );
 
   // build electron binary


### PR DESCRIPTION
This PR signs two dependent binaries included in the NSIS installer. These binaries are not tracked by Electron's build process (they are included by the NSIS builder instead). So we need to properly sign them by ourselves.