### PR TITLE
fix(client): fix parsing of legacy JSON

### DIFF
--- a/client/go/outline/config/config_dial_endpoint.go
+++ b/client/go/outline/config/config_dial_endpoint.go
@@ -101,11 +101,11 @@ func toDialEndpointConfig(node ConfigNode) (*DialEndpointConfig, error) {
 
 	case map[string]any:
 		// TODO: Make it type-based
-		config := &DialEndpointConfig{}
+		var config DialEndpointConfig
 		if err := mapToAny(typed, &config); err != nil {
 			return nil, err
 		}
-		return config, nil
+		return &config, nil
 
 	default:
 		return nil, fmt.Errorf("endpoint config of type %T is not supported", typed)

--- a/client/go/outline/config/parse.go
+++ b/client/go/outline/config/parse.go
@@ -20,7 +20,7 @@ import (
 	"errors"
 	"fmt"
 
-	"gopkg.in/yaml.v3"
+	"github.com/goccy/go-yaml"
 )
 
 // ConfigTypeKey is the config key used to specify the type of the config in order to select the corresponding parser.
@@ -57,8 +57,7 @@ func mapToAny(in map[string]any, out any) error {
 	if err != nil {
 		return fmt.Errorf("error marshaling to YAML: %w", err)
 	}
-	decoder := yaml.NewDecoder(bytes.NewReader(yamlText))
-	decoder.KnownFields(true)
+	decoder := yaml.NewDecoder(bytes.NewReader(yamlText), yaml.DisallowUnknownField())
 	if err := decoder.Decode(out); err != nil {
 		return fmt.Errorf("error decoding YAML: %w", err)
 	}

--- a/client/go/outline/parse.go
+++ b/client/go/outline/parse.go
@@ -97,7 +97,7 @@ func doParseTunnelConfig(input string) *InvokeMethodResult {
 				return &InvokeMethodResult{
 					Error: &platerrors.PlatformError{
 						Code:    platerrors.InvalidConfig,
-						Message: fmt.Sprintf("failed normalize config: %s", err),
+						Message: fmt.Sprintf("failed to normalize config: %s", err),
 					},
 				}
 			}

--- a/client/go/outline/parse.go
+++ b/client/go/outline/parse.go
@@ -20,11 +20,12 @@ import (
 	"strings"
 
 	"github.com/Jigsaw-Code/outline-apps/client/go/outline/platerrors"
-	"gopkg.in/yaml.v3"
+	"github.com/goccy/go-yaml"
+	"github.com/goccy/go-yaml/ast"
 )
 
 type parseTunnelConfigRequest struct {
-	Transport yaml.Node
+	Transport ast.Node
 	Error     *struct {
 		Message string
 		Details string

--- a/client/go/outline/parse.go
+++ b/client/go/outline/parse.go
@@ -37,6 +37,11 @@ type tunnelConfigJson struct {
 	Transport string `json:"transport"`
 }
 
+func hasKey[K comparable, V any](m map[K]V, key K) bool {
+	_, ok := m[key]
+	return ok
+}
+
 func doParseTunnelConfig(input string) *InvokeMethodResult {
 	var transportConfigText string
 
@@ -46,11 +51,11 @@ func doParseTunnelConfig(input string) *InvokeMethodResult {
 	// - Legacy Shadowsocks JSON (parsed as YAML)
 	// - New advanced YAML format
 	if strings.HasPrefix(input, "ss://") {
+		// Legacy URL format. Input is the transport config.
 		transportConfigText = input
 	} else {
-		// Parse as YAML.
-		tunnelConfig := parseTunnelConfigRequest{}
-		if err := yaml.Unmarshal([]byte(input), &tunnelConfig); err != nil {
+		var yamlValue map[string]any
+		if err := yaml.Unmarshal([]byte(input), &yamlValue); err != nil {
 			return &InvokeMethodResult{
 				Error: &platerrors.PlatformError{
 					Code:    platerrors.InvalidConfig,
@@ -59,31 +64,47 @@ func doParseTunnelConfig(input string) *InvokeMethodResult {
 			}
 		}
 
-		// Process provider error, if present.
-		if tunnelConfig.Error != nil {
-			platErr := &platerrors.PlatformError{
-				Code:    platerrors.ProviderError,
-				Message: tunnelConfig.Error.Message,
-			}
-			if tunnelConfig.Error.Details != "" {
-				platErr.Details = map[string]any{
-					"details": tunnelConfig.Error.Details,
+		if hasKey(yamlValue, "transport") || hasKey(yamlValue, "error") {
+			// New format. Parse as tunnel config
+			tunnelConfig := parseTunnelConfigRequest{}
+			if err := yaml.Unmarshal([]byte(input), &tunnelConfig); err != nil {
+				return &InvokeMethodResult{
+					Error: &platerrors.PlatformError{
+						Code:    platerrors.InvalidConfig,
+						Message: fmt.Sprintf("failed to parse: %s", err),
+					},
 				}
 			}
-			return &InvokeMethodResult{Error: platErr}
-		}
 
-		// Extract transport config as an opaque string.
-		transportConfigBytes, err := yaml.Marshal(tunnelConfig.Transport)
-		if err != nil {
-			return &InvokeMethodResult{
-				Error: &platerrors.PlatformError{
-					Code:    platerrors.InvalidConfig,
-					Message: fmt.Sprintf("failed normalize config: %s", err),
-				},
+			// Process provider error, if present.
+			if tunnelConfig.Error != nil {
+				platErr := &platerrors.PlatformError{
+					Code:    platerrors.ProviderError,
+					Message: tunnelConfig.Error.Message,
+				}
+				if tunnelConfig.Error.Details != "" {
+					platErr.Details = map[string]any{
+						"details": tunnelConfig.Error.Details,
+					}
+				}
+				return &InvokeMethodResult{Error: platErr}
 			}
+
+			// Extract transport config as an opaque string.
+			transportConfigBytes, err := yaml.Marshal(tunnelConfig.Transport)
+			if err != nil {
+				return &InvokeMethodResult{
+					Error: &platerrors.PlatformError{
+						Code:    platerrors.InvalidConfig,
+						Message: fmt.Sprintf("failed normalize config: %s", err),
+					},
+				}
+			}
+			transportConfigText = string(transportConfigBytes)
+		} else {
+			// Legacy JSON format. Input is the transport config.
+			transportConfigText = input
 		}
-		transportConfigText = string(transportConfigBytes)
 	}
 
 	result := NewClient(transportConfigText)

--- a/client/go/outline/parse_test.go
+++ b/client/go/outline/parse_test.go
@@ -79,8 +79,8 @@ func Test_doParseTunnelConfig_ProviderErrorJSON(t *testing.T) {
 	result := doParseTunnelConfig(`
 {
   "error": {
-    "message": "\u26a0 Invalid Access Key / Key \u1000\u102d\u102f\u1015\u103c\u1014\u103a\u101c\u100a\u103a\u1005\u1005\u103a\u1006\u1031\u1038\u1015\u1031\u1038\u1015\u102b\u104b",
-    "details": "\u26a0 Details / Key \u1000\u102d\u102f\u1015\u103c\u1014\u103a\u101c\u100a\u103a\u1005\u1005\u103a\u1006\u1031\u1038\u1015\u1031\u1038\u1015\u102b\u104b"
+    "message": "\u26a0 Invalid Access Key \/ Key \u1000\u102d\u102f\u1015\u103c\u1014\u103a\u101c\u100a\u103a\u1005\u1005\u103a\u1006\u1031\u1038\u1015\u1031\u1038\u1015\u102b\u104b",
+    "details": "\u26a0 Details \/ Key \u1000\u102d\u102f\u1015\u103c\u1014\u103a\u101c\u100a\u103a\u1005\u1005\u103a\u1006\u1031\u1038\u1015\u1031\u1038\u1015\u102b\u104b"
   }
 }`)
 
@@ -108,14 +108,3 @@ error:
 		},
 	}, result.Error)
 }
-
-/*
-// TODO: Fix YAML parsing so it supports escaped slash:
-// See: https://github.com/go-yaml/yaml/issues/967
-func Test_doParseTunnelConfig_parseJSON(t *testing.T) {
-	text := `"\/"`
-	var value any
-	require.NoError(t, json.Unmarshal([]byte(text), &value))
-	require.NoError(t, yaml.Unmarshal([]byte(text), &value))
-}
-*/

--- a/client/go/outline/parse_test.go
+++ b/client/go/outline/parse_test.go
@@ -108,3 +108,14 @@ error:
 		},
 	}, result.Error)
 }
+
+/*
+// TODO: Fix YAML parsing so it supports escaped slash:
+// See: https://github.com/go-yaml/yaml/issues/967
+func Test_doParseTunnelConfig_parseJSON(t *testing.T) {
+	text := `"\/"`
+	var value any
+	require.NoError(t, json.Unmarshal([]byte(text), &value))
+	require.NoError(t, yaml.Unmarshal([]byte(text), &value))
+}
+*/

--- a/client/go/outline/parse_test.go
+++ b/client/go/outline/parse_test.go
@@ -74,3 +74,19 @@ error:
 		},
 	})
 }
+
+func Test_doParseTunnelConfig_ProviderErrorUTF8(t *testing.T) {
+	result := doParseTunnelConfig(`
+error:
+  message: "\u26a0 Invalid Access Key / Key \u1000\u102d\u102f\u1015\u103c\u1014\u103a\u101c\u100a\u103a\u1005\u1005\u103a\u1006\u1031\u1038\u1015\u1031\u1038\u1015\u102b\u104b"
+  details: "\u26a0 Details / Key \u1000\u102d\u102f\u1015\u103c\u1014\u103a\u101c\u100a\u103a\u1005\u1005\u103a\u1006\u1031\u1038\u1015\u1031\u1038\u1015\u102b\u104b"
+`)
+
+	require.Equal(t, &platerrors.PlatformError{
+		Code:    platerrors.ProviderError,
+		Message: "⚠ Invalid Access Key / Key ကိုပြန်လည်စစ်ဆေးပေးပါ။",
+		Details: map[string]any{
+			"details": "⚠ Details / Key ကိုပြန်လည်စစ်ဆေးပေးပါ။",
+		},
+	}, result.Error)
+}

--- a/client/go/outline/parse_test.go
+++ b/client/go/outline/parse_test.go
@@ -55,7 +55,7 @@ transport:
 
 	require.Nil(t, result.Error)
 	require.Equal(t,
-		"{\"firstHop\":\"example.com:80\",\"transport\":\"$type: tcpudp\\ntcp: \\u0026shared\\n    $type: shadowsocks\\n    endpoint: example.com:80\\n    cipher: chacha20-ietf-poly1305\\n    secret: SECRET\\nudp: *shared\\n\"}",
+		"{\"firstHop\":\"example.com:80\",\"transport\":\"  $type: tcpudp\\n  tcp: \\u0026shared\\n    $type: shadowsocks\\n    endpoint: example.com:80\\n    cipher: chacha20-ietf-poly1305\\n    secret: SECRET\\n  udp: *shared\\n\"}",
 		result.Value)
 }
 

--- a/client/go/outline/parse_test.go
+++ b/client/go/outline/parse_test.go
@@ -21,6 +21,27 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func Test_doParseTunnel_SSURL(t *testing.T) {
+	result := doParseTunnelConfig("ss://Y2hhY2hhMjAtaWV0Zi1wb2x5MTMwNTpTRUNSRVQ@example.com:4321/")
+	require.Nil(t, result.Error)
+	require.Equal(t,
+		"{\"firstHop\":\"example.com:4321\",\"transport\":\"ss://Y2hhY2hhMjAtaWV0Zi1wb2x5MTMwNTpTRUNSRVQ@example.com:4321/\"}",
+		result.Value)
+}
+
+func Test_doParseTunnel_LegacyJSON(t *testing.T) {
+	result := doParseTunnelConfig(`{
+    "server": "example.com",
+    "server_port": 4321,
+    "method": "chacha20-ietf-poly1305",
+    "password": "SECRET"
+}`)
+	require.Nil(t, result.Error)
+	require.Equal(t,
+		"{\"firstHop\":\"example.com:4321\",\"transport\":\"{\\n    \\\"server\\\": \\\"example.com\\\",\\n    \\\"server_port\\\": 4321,\\n    \\\"method\\\": \\\"chacha20-ietf-poly1305\\\",\\n    \\\"password\\\": \\\"SECRET\\\"\\n}\"}",
+		result.Value)
+}
+
 func Test_doParseTunnelConfig(t *testing.T) {
 	result := doParseTunnelConfig(`
 transport:

--- a/client/go/outline/parse_test.go
+++ b/client/go/outline/parse_test.go
@@ -75,6 +75,24 @@ error:
 	})
 }
 
+func Test_doParseTunnelConfig_ProviderErrorJSON(t *testing.T) {
+	result := doParseTunnelConfig(`
+{
+  "error": {
+    "message": "\u26a0 Invalid Access Key / Key \u1000\u102d\u102f\u1015\u103c\u1014\u103a\u101c\u100a\u103a\u1005\u1005\u103a\u1006\u1031\u1038\u1015\u1031\u1038\u1015\u102b\u104b",
+    "details": "\u26a0 Details / Key \u1000\u102d\u102f\u1015\u103c\u1014\u103a\u101c\u100a\u103a\u1005\u1005\u103a\u1006\u1031\u1038\u1015\u1031\u1038\u1015\u102b\u104b"
+  }
+}`)
+
+	require.Equal(t, &platerrors.PlatformError{
+		Code:    platerrors.ProviderError,
+		Message: "⚠ Invalid Access Key / Key ကိုပြန်လည်စစ်ဆေးပေးပါ။",
+		Details: map[string]any{
+			"details": "⚠ Details / Key ကိုပြန်လည်စစ်ဆေးပေးပါ။",
+		},
+	}, result.Error)
+}
+
 func Test_doParseTunnelConfig_ProviderErrorUTF8(t *testing.T) {
 	result := doParseTunnelConfig(`
 error:

--- a/go.mod
+++ b/go.mod
@@ -8,13 +8,13 @@ require (
 	github.com/Wifx/gonetworkmanager/v2 v2.1.0
 	github.com/eycorsican/go-tun2socks v1.16.11
 	github.com/go-task/task/v3 v3.36.0
+	github.com/goccy/go-yaml v1.15.19
 	github.com/google/addlicense v1.1.1
 	github.com/google/go-licenses v1.6.0
 	github.com/songgao/water v0.0.0-20200317203138-2b4b6d7c09d8
 	github.com/stretchr/testify v1.9.0
 	golang.org/x/mobile v0.0.0-20241213221354-a87c1cf6cf46
 	golang.org/x/sys v0.28.0
-	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
@@ -61,6 +61,7 @@ require (
 	gopkg.in/src-d/go-billy.v4 v4.3.2 // indirect
 	gopkg.in/src-d/go-git.v4 v4.13.1 // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/klog/v2 v2.80.1 // indirect
 	mvdan.cc/sh/v3 v3.8.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -132,6 +132,8 @@ github.com/go-task/slim-sprig/v3 v3.0.0 h1:sUs3vkvUymDpBKi3qH1YSqBQk9+9D/8M2mN1v
 github.com/go-task/slim-sprig/v3 v3.0.0/go.mod h1:W848ghGpv3Qj3dhTPRyJypKRiqCdHZiAzKg9hl15HA8=
 github.com/go-task/task/v3 v3.36.0 h1:XVJ5hQ5hdzTAulHpAGzbUMUuYr9MUOEQFOFazI3hUsY=
 github.com/go-task/task/v3 v3.36.0/go.mod h1:XBCIAzuyG/mgZVHMUm3cCznz4+IpsBQRlW1gw7OA5sA=
+github.com/goccy/go-yaml v1.15.19 h1:ivDxLiW6SbmqPZwSAM9Yq+Yr68C9FLbTNyuH3ITizxQ=
+github.com/goccy/go-yaml v1.15.19/go.mod h1:XBurs7gK8ATbW4ZPGKgcbrY1Br56PdM69F7LkFRi1kA=
 github.com/godbus/dbus/v5 v5.1.0 h1:4KLkAxT3aOY8Li4FRJe/KvhoNFFxo0m6fNuFUO8QJUk=
 github.com/godbus/dbus/v5 v5.1.0/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=


### PR DESCRIPTION
Fixes https://github.com/Jigsaw-Code/outline-apps/issues/2373

This also fixes another issue that went unnoticed before @khantzawhein raised it: our YAML parser was not correctly parsing escaped slashes. That was a [bug in go-yaml](https://github.com/go-yaml/yaml/issues/967). I fixed it by migrating our code to https://github.com/goccy/go-yaml.