### PR TITLE
feat(client): add open-in-new icons to external links

### DIFF
--- a/client/src/www/views/root_view/root_navigation/index.ts
+++ b/client/src/www/views/root_view/root_navigation/index.ts
@@ -99,6 +99,13 @@ export class RootNavigation extends LitElement {
       height: 100%;
       text-decoration: none;
       width: 100%;
+      display: flex;
+      align-items: center;
+    }
+
+    #open-in-new-icon {
+      font-size: 16px;
+      height: 16px;
     }
 
     .selected {
@@ -130,6 +137,8 @@ export class RootNavigation extends LitElement {
     li > a {
       text-decoration: none;
       color: var(--outline-medium-gray);
+      display: flex;
+      align-items: center;
     }
 
     .backdrop {
@@ -194,7 +203,8 @@ export class RootNavigation extends LitElement {
             <md-ripple></md-ripple>
             <md-icon slot="start">help</md-icon>
             <a href="https://support.getoutline.org">
-              ${this.localize('help-page-title')}
+              <span>${this.localize('help-page-title')}</span>
+              <md-icon id="open-in-new-icon">open_in_new</md-icon>
             </a>
           </md-list-item>
           <md-list-item @click=${() => this.changePage('language')}>
@@ -214,11 +224,13 @@ export class RootNavigation extends LitElement {
           <li>
             <a href="https://www.google.com/policies/privacy/">
               ${this.localize('privacy')}
+              <md-icon id="open-in-new-icon">open_in_new</md-icon>
             </a>
           </li>
           <li>
             <a href="${this.dataCollectionPageUrl}">
               ${this.localize('data-collection')}
+              <md-icon id="open-in-new-icon">open_in_new</md-icon>
             </a>
           </li>
           <li>
@@ -226,6 +238,7 @@ export class RootNavigation extends LitElement {
               href="https://s3.amazonaws.com/outline-vpn/static_downloads/Outline-Terms-of-Service.html"
             >
               ${this.localize('terms')}
+              <md-icon id="open-in-new-icon">open_in_new</md-icon>
             </a>
           </li>
           <li @click=${() => this.changePage('licenses')}>

--- a/server_manager/www/ui_components/app-root.ts
+++ b/server_manager/www/ui_components/app-root.ts
@@ -293,6 +293,10 @@ export class AppRoot extends polymerElementWithLocalize {
       #language-icon {
         padding-top: 10px;
       }
+      #open-in-new-icon {
+        width: 16px;
+        height: 16px;
+      }
       #language-dropdown {
         padding-left: 22px;
         --paper-input-container: {
@@ -392,17 +396,27 @@ export class AppRoot extends polymerElementWithLocalize {
                 class="manager-resources-link"
                 href="https://www.reddit.com/r/outlinevpn/wiki/index/">
                   <span>[[localize('manager-resources')]]</span>
-                  <iron-icon icon="open-in-new" />
+                  <iron-icon id="open-in-new-icon" icon="open-in-new" />
               </a>
             </if-messages>
-            <span on-tap="maybeCloseDrawer"><a href="https://support.google.com/outline/answer/15331222">[[localize('nav-data-collection')]]</a></span>
+            <span on-tap="maybeCloseDrawer">
+              <a href="https://support.google.com/outline/answer/15331222">
+                <span>[[localize('nav-data-collection')]]</span>
+                <iron-icon id="open-in-new-icon" icon="open-in-new" />
+              </a>
+            </span>
             <template is="dom-if" if="{{featureFlags.contactView}}">
               <span on-tap="submitFeedbackTapped">[[localize('nav-contact-us')]]</span>
             </template>
             <template is="dom-if" if="{{!featureFlags.contactView}}">
               <span on-tap="submitFeedbackTapped">[[localize('nav-feedback')]]</span>
             </template>
-            <span on-tap="maybeCloseDrawer"><a href="https://support.google.com/outline/">[[localize('nav-help')]]</a></span>
+            <span on-tap="maybeCloseDrawer">
+              <a href="https://support.google.com/outline/">
+                <span>[[localize('nav-help')]]</span>
+                <iron-icon id="open-in-new-icon" icon="open-in-new" />
+              </a>
+            </span>
             <span on-tap="aboutTapped">[[localize('nav-about')]]</span>
             <div id="links-footer">
               <paper-icon-item id="language-row">
@@ -410,8 +424,14 @@ export class AppRoot extends polymerElementWithLocalize {
                 <outline-language-picker id="language-dropdown" selected-language="{{language}}" languages="{{supportedLanguages}}"></outline-language-picker>
               </paper-icon-item>
               <div class="legal-links" on-tap="maybeCloseDrawer">
-                <a href="https://www.google.com/policies/privacy/">[[localize('nav-privacy')]]</a>
-                <a href="https://s3.amazonaws.com/outline-vpn/static_downloads/Outline-Terms-of-Service.html">[[localize('nav-terms')]]</a>
+                <a href="https://www.google.com/policies/privacy/">
+                  <span>[[localize('nav-privacy')]]</span>
+                  <iron-icon id="open-in-new-icon" icon="open-in-new" />
+                </a>
+                <a href="https://s3.amazonaws.com/outline-vpn/static_downloads/Outline-Terms-of-Service.html">
+                  <span>[[localize('nav-terms')]]</span>
+                  <iron-icon id="open-in-new-icon" icon="open-in-new" />
+                </a>
                 <span on-tap="showLicensesTapped">[[localize('nav-licenses')]]</span>
               </div>
             </div>


### PR DESCRIPTION
Add open-in-new icons to sidebar links where opening in a new tab might be unexpected, on both the client and the server. Fixes https://github.com/Jigsaw-Code/outline-apps/issues/2348 (which has mysteriously disappeared, but was asking for indicators on external links).

Client:
- Added an icon to the 'Help', 'Privacy', 'Data collection' and 'Terms' links
<img width="495" alt="Screenshot 2025-03-04 at 12 33 20" src="https://github.com/user-attachments/assets/651e0117-257b-4d57-aa24-19d7afd3fb01" />

Server:
- Added an icon to the 'Data Collection', 'Help', 'Privacy' and 'Terms' links
<img width="495" alt="Screenshot 2025-03-04 at 12 50 48" src="https://github.com/user-attachments/assets/5af650cb-bd5c-41f8-9e3a-8ba23d5e7f44" />



