### PR TITLE
fix(client/linux): patch RPATH during build time rather than runtime

### DIFF
--- a/.github/workflows/build_and_test_debug_client.yml
+++ b/.github/workflows/build_and_test_debug_client.yml
@@ -77,7 +77,7 @@ jobs:
 
   linux_debug_build:
     name: Linux Debug Build
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     timeout-minutes: 20
     needs: [web_test, backend_test]
     steps:

--- a/client/electron/README.md
+++ b/client/electron/README.md
@@ -26,7 +26,9 @@ You can download the binary tarball, or [use a package manager](https://github.c
 brew install zig 
 ```
 
-## Requirements for building from Windows
+## Requirements
+
+### Windows
 
 - Visual Studio 2022 or later
 
@@ -34,6 +36,13 @@ If you see an error about `node-gyp` not finding Visual Studio, try one of the f
 
 - (Recommended) Install the VSSetup PowerShell package using `Install-Module VSSetup -Scope CurrentUser`
 - Change PowerShell LanguageMode using `$ExecutionContext.SessionState.LanguageMode="FullLanguage"`
+
+### Linux
+
+- `patchelf` 0.14+ is required for building the Debian package:
+  - Debian/Ubuntu: `sudo apt install patchelf`
+  - macOS: `brew install patchelf`
+  - Windows: https://github.com/NixOS/patchelf/releases
 
 ## Release
 

--- a/client/electron/debian/after_install.sh
+++ b/client/electron/debian/after_install.sh
@@ -16,14 +16,8 @@
 
 # Dependencies:
 #   - libcap2-bin: setcap
-#   - patchelf: patchelf
 
 set -eux
-
-# Capabilitites will disable LD_LIBRARY_PATH, and $ORIGIN evaluation in binary's
-# rpath. So we need to set the rpath to an absolute path. (for libffmpeg.so)
-# This command will also reset capabilitites, so we need to run this before setcap.
-/usr/bin/patchelf --add-rpath /opt/Outline /opt/Outline/Outline
 
 # Grant specific capabilities so Outline can run without root permisssion
 #   - cap_net_admin: configure network interfaces, set up routing tables, etc.

--- a/client/electron/electron-builder.json
+++ b/client/electron/electron-builder.json
@@ -17,10 +17,12 @@
     "!output/client/electron/build"
   ],
 
+  "beforePack": "client/electron/hooks/before_pack.cjs",
+
   "deb": {
     "depends": [
       "libnotify4", "libxtst6", "libnss3",
-      "libcap2-bin", "patchelf"
+      "libcap2-bin"
     ],
     "afterInstall": "client/electron/debian/after_install.sh"
   },

--- a/client/electron/electron-builder.json
+++ b/client/electron/electron-builder.json
@@ -17,7 +17,7 @@
     "!output/client/electron/build"
   ],
 
-  "beforePack": "client/electron/hooks/before_pack.cjs",
+  "afterPack": "client/electron/hooks/after_pack.cjs",
 
   "deb": {
     "depends": [

--- a/client/electron/hooks/after_pack.cjs
+++ b/client/electron/hooks/after_pack.cjs
@@ -61,6 +61,9 @@ function patchLinuxRPath(binDir) {
   }
 }
 
+/**
+ * Run after pack but before pack into distributable format and sign.
+ */
 exports.default = function (buildResult) {
   if (buildResult.electronPlatformName === 'linux') {
     patchLinuxRPath(buildResult.appOutDir);

--- a/client/electron/hooks/before_pack.cjs
+++ b/client/electron/hooks/before_pack.cjs
@@ -1,0 +1,68 @@
+// Copyright 2025 The Outline Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// CommonJS module is required, ES6 module is not supported by electron-builder
+
+const {execSync} = require('node:child_process');
+const {join} = require('node:path');
+
+/**
+ * Patches the RPATH of the Outline binary in the Debian package.
+ *
+ * This is necessary because setting capabilities (setcap) on the binary
+ * disables `LD_LIBRARY_PATH` and relative RPATH (e.g., `$ORIGIN`), preventing
+ * the app from finding libraries (like libffmpeg.so) in the install directory.
+ * So we need to add the absolute path of the install directory to RPATH.
+ *
+ * We also need to patch the RPATH at build time because the user's system
+ * might not have a compatible `patchelf` at runtime.
+ *
+ * @param {string} binDir The directory containing the built Outline binary.
+ * @throws {Error} If `patchelf` is not found or if the RPATH modification fails.
+ */
+function patchLinuxRPath(binDir) {
+  const outlineBinFile = join(binDir, 'Outline');
+
+  try {
+    console.log(`Patching RPATH for ${outlineBinFile}`);
+    execSync('patchelf --version', {stdio: 'inherit'});
+  } catch (e) {
+    console.error('`patchelf --version` failed, `patchelf` is required');
+    console.error('Install `patchelf` using:');
+    console.error('\tDebian:  sudo apt install patchelf');
+    console.error('\tmacOS:   brew install patchelf');
+    console.error('\tWindows: https://github.com/NixOS/patchelf/releases');
+    throw e;
+  }
+
+  try {
+    const DebianInstallFolder = '/opt/Outline';
+    execSync(
+      `patchelf --add-rpath "${DebianInstallFolder}" "${outlineBinFile}"`,
+      {
+        stdio: 'inherit',
+      }
+    );
+    console.info(`RPATH patched for ${outlineBinFile}`);
+  } catch (e) {
+    console.error(`Failed to patch RPATH for ${outlineBinFile}`);
+    throw e;
+  }
+}
+
+exports.default = function (buildResult) {
+  if (buildResult.electronPlatformName === 'linux') {
+    patchLinuxRPath(buildResult.appOutDir);
+  }
+};

--- a/client/tsconfig.json
+++ b/client/tsconfig.json
@@ -17,5 +17,5 @@
     "lib": ["es2022"]
   },
   "exclude": ["*.cjs", "*.js", "*.mjs", "**/*.spec.ts"],
-  "include": ["src"]
+  "include": ["src", "electron"]
 }


### PR DESCRIPTION
Move `patchelf` RPATH patching from Debian installation time to build time.

This fixes an issue where the application would fail to install on systems without an up-to-date `patchelf` (for example, Ubuntu 18).