### PR TITLE
ci(client): disable cache for setup-zig action

### DIFF
--- a/.github/workflows/build_and_test_debug_client.yml
+++ b/.github/workflows/build_and_test_debug_client.yml
@@ -103,7 +103,7 @@ jobs:
         uses: mlugg/setup-zig@v1
         with:
           version: 0.13.0
-        use-cache: false
+          use-cache: false
 
       - name: Build Linux Client
         run: npm run action client/electron/build linux
@@ -139,7 +139,7 @@ jobs:
         uses: mlugg/setup-zig@v1
         with:
           version: 0.13.0
-        use-cache: false
+          use-cache: false
 
       - name: Build Windows Client
         run: npm run action client/electron/build windows

--- a/.github/workflows/build_and_test_debug_client.yml
+++ b/.github/workflows/build_and_test_debug_client.yml
@@ -103,6 +103,7 @@ jobs:
         uses: mlugg/setup-zig@v1
         with:
           version: 0.13.0
+        use-cache: false
 
       - name: Build Linux Client
         run: npm run action client/electron/build linux
@@ -138,6 +139,7 @@ jobs:
         uses: mlugg/setup-zig@v1
         with:
           version: 0.13.0
+        use-cache: false
 
       - name: Build Windows Client
         run: npm run action client/electron/build windows


### PR DESCRIPTION
The cache for the `setup-zig` action has been causing intermittent build failures. This change disables the cache to improve build reliability, trading off potential performance gains.