### PR TITLE
chore: allow `deps` as a commitlint scope

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -27,6 +27,7 @@ module.exports = {
         'client/linux',
         'client/macos',
         'client/windows',
+        'deps',
         'devtools',
         'docs',
         'infrastructure',


### PR DESCRIPTION
For any dependabot PRs we do want to merge, it uses this scope.