### PR TITLE
chore(client): remove setUnderlyingNetwork and other minor cleanup

### DIFF
--- a/client/src/cordova/android/OutlineAndroidLib/outline/src/main/java/org/outline/vpn/VpnTunnel.java
+++ b/client/src/cordova/android/OutlineAndroidLib/outline/src/main/java/org/outline/vpn/VpnTunnel.java
@@ -83,11 +83,6 @@ public class VpnTunnel {
               .setBlocking(true)
               .addDisallowedApplication(vpnService.getPackageName());
 
-      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-        final Network activeNetwork =
-            vpnService.getSystemService(ConnectivityManager.class).getActiveNetwork();
-        builder.setUnderlyingNetworks(new Network[] {activeNetwork});
-      }
       if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
         builder.setMetered(false);
       }

--- a/client/src/cordova/android/OutlineAndroidLib/outline/src/main/java/org/outline/vpn/VpnTunnel.java
+++ b/client/src/cordova/android/OutlineAndroidLib/outline/src/main/java/org/outline/vpn/VpnTunnel.java
@@ -46,7 +46,6 @@ public class VpnTunnel {
   private static final String PRIVATE_LAN_BYPASS_SUBNETS_ID = "reserved_bypass_subnets";
 
   private final VpnTunnelService vpnService;
-  private String dnsResolverAddress;
   private ParcelFileDescriptor tunFd;
   private Tunnel tunnel;
 
@@ -72,7 +71,7 @@ public class VpnTunnel {
   public synchronized boolean establishVpn() {
     LOG.info("Establishing the VPN.");
     try {
-      dnsResolverAddress = selectDnsResolverAddress();
+      String dnsResolverAddress = selectDnsResolverAddress();
       VpnService.Builder builder =
           vpnService.newBuilder()
               .setSession(vpnService.getApplicationName())

--- a/client/src/cordova/android/OutlineAndroidLib/outline/src/main/java/org/outline/vpn/VpnTunnel.java
+++ b/client/src/cordova/android/OutlineAndroidLib/outline/src/main/java/org/outline/vpn/VpnTunnel.java
@@ -71,14 +71,13 @@ public class VpnTunnel {
   public synchronized boolean establishVpn() {
     LOG.info("Establishing the VPN.");
     try {
-      String dnsResolverAddress = selectDnsResolverAddress();
       VpnService.Builder builder =
           vpnService.newBuilder()
               .setSession(vpnService.getApplicationName())
               .setMtu(VPN_INTERFACE_MTU)
               .addAddress(String.format(Locale.ROOT, VPN_INTERFACE_PRIVATE_LAN, "1"),
                   VPN_INTERFACE_PREFIX_LENGTH)
-              .addDnsServer(dnsResolverAddress)
+              .addDnsServer(selectDnsResolverAddress())
               .setBlocking(true)
               .addDisallowedApplication(vpnService.getPackageName());
 

--- a/client/src/cordova/android/OutlineAndroidLib/outline/src/main/java/org/outline/vpn/VpnTunnelService.java
+++ b/client/src/cordova/android/OutlineAndroidLib/outline/src/main/java/org/outline/vpn/VpnTunnelService.java
@@ -210,7 +210,9 @@ public class VpnTunnelService extends VpnService {
       try {
         // Do not perform connectivity checks when connecting on startup. We should avoid failing
         // the connection due to a network error, as network may not be ready.
-        final TCPAndUDPConnectivityResult connResult = checkServerConnectivity(client);
+        final TCPAndUDPConnectivityResult connResult = Outline.checkTCPAndUDPConnectivity(client);
+        LOG.info(String.format(Locale.ROOT, "Go connectivity check result: %s", connResult));
+
         if (connResult.getTCPError() != null) {
           tearDownActiveTunnel();
           return connResult.getTCPError();
@@ -286,12 +288,6 @@ public class VpnTunnelService extends VpnService {
   }
 
   // Connectivity
-
-  private TCPAndUDPConnectivityResult checkServerConnectivity(final outline.Client client) {
-    final TCPAndUDPConnectivityResult result = Outline.checkTCPAndUDPConnectivity(client);
-    LOG.info(String.format(Locale.ROOT, "Go connectivity check result: %s", result));
-    return result;
-  }
 
   private class NetworkConnectivityMonitor extends ConnectivityManager.NetworkCallback {
     private final ConnectivityManager connectivityManager;

--- a/client/src/cordova/android/OutlineAndroidLib/outline/src/main/java/org/outline/vpn/VpnTunnelService.java
+++ b/client/src/cordova/android/OutlineAndroidLib/outline/src/main/java/org/outline/vpn/VpnTunnelService.java
@@ -74,7 +74,7 @@ public class VpnTunnelService extends VpnService {
   }
 
   // IPC message and intent parameters.
-  private enum MessageData {
+  public enum MessageData {
     TUNNEL_ID("tunnelId"),
     PAYLOAD("payload"),
     ERROR_REPORTING_API_KEY("errorReportingApiKey");

--- a/client/src/cordova/android/OutlineAndroidLib/outline/src/main/java/org/outline/vpn/VpnTunnelService.java
+++ b/client/src/cordova/android/OutlineAndroidLib/outline/src/main/java/org/outline/vpn/VpnTunnelService.java
@@ -311,15 +311,6 @@ public class VpnTunnelService extends VpnService {
       broadcastVpnConnectivityChange(TunnelStatus.CONNECTED);
       updateNotification(TunnelStatus.CONNECTED);
 
-      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-        // Indicate that traffic will be sent over the current active network.
-        // Although setting the underlying network to an available network may not seem like the
-        // correct behavior, this method has been observed only to fire only when a preferred
-        // network becomes available. It will not fire, for example, when the mobile network becomes
-        // available if WiFi is the active network. Additionally, `getActiveNetwork` and
-        // `getActiveNetworkInfo` have been observed to return the underlying network set by us.
-        setUnderlyingNetworks(new Network[] {network});
-      }
       boolean isUdpSupported = vpnTunnel.updateUDPSupport();
       LOG.info(
           String.format("UDP support: %s -> %s", tunnelStore.isUdpSupported(), isUdpSupported));
@@ -337,10 +328,6 @@ public class VpnTunnelService extends VpnService {
       }
       broadcastVpnConnectivityChange(TunnelStatus.RECONNECTING);
       updateNotification(TunnelStatus.RECONNECTING);
-
-      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-        setUnderlyingNetworks(null);
-      }
     }
   }
 

--- a/client/src/cordova/android/OutlineAndroidLib/outline/src/main/java/org/outline/vpn/VpnTunnelService.java
+++ b/client/src/cordova/android/OutlineAndroidLib/outline/src/main/java/org/outline/vpn/VpnTunnelService.java
@@ -74,7 +74,7 @@ public class VpnTunnelService extends VpnService {
   }
 
   // IPC message and intent parameters.
-  public enum MessageData {
+  private enum MessageData {
     TUNNEL_ID("tunnelId"),
     PAYLOAD("payload"),
     ERROR_REPORTING_API_KEY("errorReportingApiKey");


### PR DESCRIPTION
This doesn't seem to be needed anymore, and just adds complexity.

To test, I ran on the emulator and checked the metered interfaces with and without the wifi while the VPN is on.

When only cell (metered) is on, we see both `eth0` and `tun1` being marked as metered:

```
% adb shell dumpsys netpolicy | head -8
System ready: true
Restrict background: false
Restrict power: false
Device idle: false
Restricted networking mode: false
Low Power Standby mode: false
Metered ifaces: {eth0, tun1}
```

The VPN inherits from the underlying default network.


If I turn on the Wifi, the `tun1` device no longer shows up as metered:

```
% adb shell dumpsys netpolicy | head -8 
System ready: true
Restrict background: false
Restrict power: false
Device idle: false
Restricted networking mode: false
Low Power Standby mode: false
Metered ifaces: {eth0}
```

If I go to the Wifi settings, and mark the Wifi network as metered, then the `tun1` device is again marked as metered:

```
% adb shell dumpsys netpolicy | head -8
System ready: true
Restrict background: false
Restrict power: false
Device idle: false
Restricted networking mode: false
Low Power Standby mode: false
Metered ifaces: {eth0, tun1}
```

So we no longer need `setUnderlyingNetwork` for the VPN to match the underlying network metered status (https://b.corp.google.com/issues/68657525).

My goal with this was to remove the `addDisallowedApplication` call that is giving us trouble, but I still need to test that. I will probably send that on another PR.

/cc @62w71st