### PR TITLE
fix(client/linux): upgrade Koffi to resolve bundle issue

### DIFF
--- a/client/electron/electron-builder.json
+++ b/client/electron/electron-builder.json
@@ -16,7 +16,11 @@
     "name": "outline-client",
     "main": "output/client/electron/index.js"
   },
-  "extraResources": ["node_modules/koffi/build/koffi"],
+  "extraResources": [{
+    "from": "node_modules/koffi/build/koffi",
+    "to": "koffi",
+    "filter": ["**/*"]
+  }],
   "files": [
     "client/www",
     "client/resources/tray",

--- a/client/electron/electron-builder.json
+++ b/client/electron/electron-builder.json
@@ -16,11 +16,6 @@
     "name": "outline-client",
     "main": "output/client/electron/index.js"
   },
-  "extraResources": [{
-    "from": "node_modules/koffi/build/koffi",
-    "to": "koffi",
-    "filter": ["**/*"]
-  }],
   "files": [
     "client/www",
     "client/resources/tray",

--- a/client/electron/electron-builder.json
+++ b/client/electron/electron-builder.json
@@ -16,6 +16,7 @@
     "name": "outline-client",
     "main": "output/client/electron/index.js"
   },
+  "extraResources": ["node_modules/koffi/build/koffi"],
   "files": [
     "client/www",
     "client/resources/tray",

--- a/client/package.json
+++ b/client/package.json
@@ -49,7 +49,7 @@
     "electron-updater": "^5.0.5",
     "element-internals-polyfill": "^1.3.12",
     "fs-extra": "^11.2.0",
-    "koffi": "^2.9.1",
+    "koffi": "^2.12.0",
     "lit": "^3.2.1",
     "ShadowsocksConfig": "github:Jigsaw-Code/outline-shadowsocksconfig#v0.2.1",
     "socks": "^1.1.10",

--- a/package-lock.json
+++ b/package-lock.json
@@ -85,7 +85,7 @@
         "electron-updater": "^5.0.5",
         "element-internals-polyfill": "^1.3.12",
         "fs-extra": "^11.2.0",
-        "koffi": "^2.9.1",
+        "koffi": "^2.12.0",
         "lit": "^3.2.1",
         "ShadowsocksConfig": "github:Jigsaw-Code/outline-shadowsocksconfig#v0.2.1",
         "socks": "^1.1.10",
@@ -23534,10 +23534,11 @@
       }
     },
     "node_modules/koffi": {
-      "version": "2.9.1",
-      "resolved": "https://registry.npmjs.org/koffi/-/koffi-2.9.1.tgz",
-      "integrity": "sha512-LXYOzaiUB8XK7EwbG0tgzhajEr3FLS2RB9oHYbTOiWRQQO+Rgft3xSvd5TFlM3wQ6DMMQG41lvUR5gLgdyWIsA==",
-      "hasInstallScript": true
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/koffi/-/koffi-2.12.0.tgz",
+      "integrity": "sha512-J886y/bvoGG4ZhMVstB2Nh6/q9tzAYn0kaH7Ss8DWavGIxP5jOLzUY9IZzw9pMuXArj0SLSpl0MYsKRURPAv7g==",
+      "hasInstallScript": true,
+      "license": "MIT"
     },
     "node_modules/last-run": {
       "version": "1.1.1",
@@ -39621,7 +39622,7 @@
         "karma-coverage-istanbul-reporter": "^3.0.3",
         "karma-jasmine": "^4.0.1",
         "karma-webpack": "^5.0.0",
-        "koffi": "^2.9.1",
+        "koffi": "^2.12.0",
         "lit": "^3.2.1",
         "lit-analyzer": "^2.0.3",
         "minimist": "^1.2.6",
@@ -53684,9 +53685,9 @@
       }
     },
     "koffi": {
-      "version": "2.9.1",
-      "resolved": "https://registry.npmjs.org/koffi/-/koffi-2.9.1.tgz",
-      "integrity": "sha512-LXYOzaiUB8XK7EwbG0tgzhajEr3FLS2RB9oHYbTOiWRQQO+Rgft3xSvd5TFlM3wQ6DMMQG41lvUR5gLgdyWIsA=="
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/koffi/-/koffi-2.12.0.tgz",
+      "integrity": "sha512-J886y/bvoGG4ZhMVstB2Nh6/q9tzAYn0kaH7Ss8DWavGIxP5jOLzUY9IZzw9pMuXArj0SLSpl0MYsKRURPAv7g=="
     },
     "last-run": {
       "version": "1.1.1",


### PR DESCRIPTION
This PR fixes the `Error: Cannot find the native Koffi module` on certain Linux systems.

The issue stemmed from Koffi 2.9.1 requires an executable stack (`execstack`). Some newer or security-focused systems (like Ubuntu 25 and Debian 13) disallow this, preventing the module from loading: `koffi.node: cannot enable executable stack as shared object requires: Invalid argument`.

So this PR upgrades Koffi to `v2.12.0` because [since `v2.10.0`, koffi no longer requires the executable stack (`-z noexecstack`)](https://koffi.dev/changelog#koffi-2-10-0).

Fixes #2491


Tested on: Debian Rodete