### PR TITLE
fix(manager): upgrade deprecated Ubuntu image

### DIFF
--- a/server_manager/www/gcp_account.ts
+++ b/server_manager/www/gcp_account.ts
@@ -272,7 +272,7 @@ export class GcpAccount implements gcp.Account {
           boot: true,
           initializeParams: {
             sourceImage:
-              'projects/ubuntu-os-cloud/global/images/family/ubuntu-2004-lts',
+              'projects/ubuntu-os-cloud/global/images/family/ubuntu-2204-lts',
           },
         },
       ],


### PR DESCRIPTION
`ubuntu-2004-lts` is no longer supported as of May 2025. Let's upgrade to `ubuntu2204-lts`, which will be supported for the next two years.

More Info: https://cloud.google.com/compute/docs/images/os-details#ubuntu_lts

Fixes #2534 