### PR TITLE
chore(client): upgrade android target api version to 35

### DIFF
--- a/.github/scripts/android_setup_ci.sh
+++ b/.github/scripts/android_setup_ci.sh
@@ -46,4 +46,4 @@ PATH="${PATH}:${ANDROID_HOME}/platform-tools:${ANDROID_HOME}/cmdline-tools/tools
 # To find the latest version's label:
 #   sdkmanager --list|grep build-tools
 # NDK (side by side) version must be kept in sync with the default build tools NDK version.
-yes | sdkmanager "build-tools;34.0.0" "ndk;25.1.8937393"
+yes | sdkmanager "build-tools;35.0.0" "ndk;26.1.10909125"

--- a/client/config.xml
+++ b/client/config.xml
@@ -24,7 +24,7 @@
     <allow-intent href="http://*/*" />
     <allow-intent href="https://*/*" />
     <preference name="android-minSdkVersion" value="29" />
-    <preference name="android-targetSdkVersion" value="34" />
+    <preference name="android-targetSdkVersion" value="35" />
     <preference name="AndroidLaunchMode" value="singleInstance" />
     <preference name="ShowSplashScreenSpinner" value="false" />
 

--- a/client/package.json
+++ b/client/package.json
@@ -76,7 +76,7 @@
     "chalk": "^5.0.1",
     "copy-dir": "^1.3.0",
     "copy-webpack-plugin": "^5.1.1",
-    "cordova-android": "^13.0.0",
+    "cordova-android": "^14.0.0",
     "cordova-browser": "~6.0.0",
     "cordova-ios": "github:apache/cordova-ios#1a5cd45e2243b239b5045a0ade9d2da1d779b72a",
     "cordova-lib": "^11.0.0",

--- a/client/src/cordova/android/OutlineAndroidLib/build.gradle
+++ b/client/src/cordova/android/OutlineAndroidLib/build.gradle
@@ -1,5 +1,5 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
     // This version number must be kept in sync with AGP_VERSION in cordova-android.
-    id 'com.android.library' version '8.3.0' apply false
+    id 'com.android.library' version '8.7.3' apply false
 }

--- a/client/src/cordova/android/OutlineAndroidLib/outline/build.gradle
+++ b/client/src/cordova/android/OutlineAndroidLib/outline/build.gradle
@@ -7,7 +7,7 @@ group = 'org.outline'
 
 android {
     namespace 'org.outline'
-    compileSdk 34
+    compileSdk 35
 
     buildFeatures {
         aidl true

--- a/client/src/cordova/android/README.md
+++ b/client/src/cordova/android/README.md
@@ -45,13 +45,13 @@ Alternatively, you can do it on the command-line:
 1. Install platform and build tools:
 
     ```shell
-    sdkmanager "platforms;android-34" "build-tools;34.0.0" "ndk;25.1.8937393" 
+    sdkmanager "platforms;android-35" "build-tools;35.0.0" "ndk;25.1.8937393" 
     ```
 
 1. Install optional components that help development (source code, emulator and image):
 
     ```shell
-    sdkmanager "sources;android-34" "system-images;android-34;default;arm64-v8a"
+    sdkmanager "sources;android-35" "system-images;android-35;default;arm64-v8a"
     ```
 
   Note: you will need the `system-images;android-35;default;x86_64` image on an Intel computer.
@@ -70,12 +70,12 @@ npx cordova requirements android
 
 | Component  | version  | constrained by | set in  |
 |---|---|---|---|
-| Android API Level | 34+ | [Play Store](https://developer.android.com/google/play/requirements/target-sdk) | [config.xml](../../../config.xml), [build.gradle](./OutlineAndroidLib/outline/build.gradle) |
-| cordova-android | 13 | Android API Level | [package.json](../../../package.json) |
+| Android API Level | 35+ | [Play Store](https://developer.android.com/google/play/requirements/target-sdk) | [config.xml](../../../config.xml), [build.gradle](./OutlineAndroidLib/outline/build.gradle) |
+| cordova-android | 14 | Android API Level | [package.json](../../../package.json) |
 | JDK | 17 | [cordova-android](https://cordova.apache.org/docs/en/latest/guide/platforms/android/index.html#android-api-level-support) | install instruction |
 | Gradle | 8.7+ | [cordova-android](https://cordova.apache.org/docs/en/latest/guide/platforms/android/index.html#android-api-level-support) | [gradle-wrapper.properties](./OutlineAndroidLib/gradle/wrapper/gradle-wrapper.properties) |
 | Android Gradle Plugin (AGP) | 8.3.0 | [cordova-android](https://cordova.apache.org/docs/en/latest/guide/platforms/android/index.html#android-api-level-support) | [build.gradle](../android/OutlineAndroidLib/build.gradle) |
-| Android Build Tools | 34.0.0+ | [cordova-android](https://cordova.apache.org/docs/en/latest/guide/platforms/android/index.html#android-api-level-support) | install instructions |
+| Android Build Tools | 35.0.0+ | [cordova-android](https://cordova.apache.org/docs/en/latest/guide/platforms/android/index.html#android-api-level-support) | install instructions |
 | Android Studio | 2023.2.1  (Iguana) | [AGP](https://developer.android.com/studio/releases#android_gradle_plugin_and_android_studio_compatibility) | |
 
 ## Build the app

--- a/client/src/cordova/android/README.md
+++ b/client/src/cordova/android/README.md
@@ -45,7 +45,7 @@ Alternatively, you can do it on the command-line:
 1. Install platform and build tools:
 
     ```shell
-    sdkmanager "platforms;android-35" "build-tools;35.0.0" "ndk;25.1.8937393" 
+    sdkmanager "platforms;android-35" "build-tools;35.0.0" "ndk;26.1.10909125" 
     ```
 
 1. Install optional components that help development (source code, emulator and image):

--- a/client/src/cordova/android/README.md
+++ b/client/src/cordova/android/README.md
@@ -74,7 +74,7 @@ npx cordova requirements android
 | cordova-android | 14 | Android API Level | [package.json](../../../package.json) |
 | JDK | 17 | [cordova-android](https://cordova.apache.org/docs/en/latest/guide/platforms/android/index.html#android-api-level-support) | install instruction |
 | Gradle | 8.7+ | [cordova-android](https://cordova.apache.org/docs/en/latest/guide/platforms/android/index.html#android-api-level-support) | [gradle-wrapper.properties](./OutlineAndroidLib/gradle/wrapper/gradle-wrapper.properties) |
-| Android Gradle Plugin (AGP) | 8.3.0 | [cordova-android](https://cordova.apache.org/docs/en/latest/guide/platforms/android/index.html#android-api-level-support) | [build.gradle](../android/OutlineAndroidLib/build.gradle) |
+| Android Gradle Plugin (AGP) | 8.7.3 | [cordova-android](https://cordova.apache.org/docs/en/latest/guide/platforms/android/index.html#android-api-level-support) | [build.gradle](../android/OutlineAndroidLib/build.gradle) |
 | Android Build Tools | 35.0.0+ | [cordova-android](https://cordova.apache.org/docs/en/latest/guide/platforms/android/index.html#android-api-level-support) | install instructions |
 | Android Studio | 2023.2.1  (Iguana) | [AGP](https://developer.android.com/studio/releases#android_gradle_plugin_and_android_studio_compatibility) | |
 

--- a/client/src/cordova/apple/xcode/macos/Outline/config.xml
+++ b/client/src/cordova/apple/xcode/macos/Outline/config.xml
@@ -52,7 +52,7 @@
     <preference name="KeyboardDisplayRequiresUserAction" value="true" />
     <preference name="MediaPlaybackRequiresUserAction" value="false" />
     <preference name="android-minSdkVersion" value="29" />
-    <preference name="android-targetSdkVersion" value="34" />
+    <preference name="android-targetSdkVersion" value="35" />
     <preference name="AndroidLaunchMode" value="singleInstance" />
     <preference name="ShowSplashScreenSpinner" value="false" />
     <preference name="deployment-target" value="10.11" />

--- a/package-lock.json
+++ b/package-lock.json
@@ -112,7 +112,7 @@
         "chalk": "^5.0.1",
         "copy-dir": "^1.3.0",
         "copy-webpack-plugin": "^5.1.1",
-        "cordova-android": "^13.0.0",
+        "cordova-android": "^14.0.0",
         "cordova-browser": "~6.0.0",
         "cordova-ios": "github:apache/cordova-ios#1a5cd45e2243b239b5045a0ade9d2da1d779b72a",
         "cordova-lib": "^11.0.0",
@@ -13091,38 +13091,37 @@
       }
     },
     "node_modules/cordova-android": {
-      "version": "13.0.0",
-      "resolved": "https://registry.npmjs.org/cordova-android/-/cordova-android-13.0.0.tgz",
-      "integrity": "sha512-uQG+cSyrB1NMi2aIzihldIupHB9WGpZVvrMMMAAtnyc6tDlEk7gweSSaFsEONyGAnteRYpIvrzg/YwDW08PcUg==",
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/cordova-android/-/cordova-android-14.0.1.tgz",
+      "integrity": "sha512-HMBMdGu/JlSQtmBuDEpKWf/pE75SpF3FksxZ+mqYuL3qSIN8lN/QsNurwYaPAP7zWXN2DNpvwlpOJItS5VhdLg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "android-versions": "^2.0.0",
-        "cordova-common": "^5.0.0",
+        "android-versions": "^2.1.0",
+        "cordova-common": "^5.0.1",
         "dedent": "^1.5.3",
         "execa": "^5.1.1",
-        "fast-glob": "^3.3.2",
-        "fs-extra": "^11.2.0",
+        "fast-glob": "^3.3.3",
         "is-path-inside": "^3.0.3",
-        "nopt": "^7.2.1",
+        "nopt": "^8.1.0",
         "properties-parser": "^0.6.0",
-        "semver": "^7.6.2",
+        "semver": "^7.7.1",
         "string-argv": "^0.3.1",
         "untildify": "^4.0.0",
-        "which": "^4.0.0"
+        "which": "^5.0.0"
       },
       "engines": {
-        "node": ">=16.13.0"
+        "node": ">=20.5.0"
       }
     },
     "node_modules/cordova-android/node_modules/abbrev": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-2.0.0.tgz",
-      "integrity": "sha512-6/mh1E2u2YgEsCHdY0Yx5oW+61gZU+1vXaoiHHrpKeuRNNgFvS+/jrwHiQhB5apAf5oB7UB7E19ol2R2LKH8hQ==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-3.0.1.tgz",
+      "integrity": "sha512-AO2ac6pjRB3SJmGJo+v5/aK6Omggp6fsLrs6wN9bd35ulu4cCwaAU9+7ZhXjeqHVkaHThLuzH0nZr0YpCDhygg==",
       "dev": true,
       "license": "ISC",
       "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+        "node": "^18.17.0 || >=20.5.0"
       }
     },
     "node_modules/cordova-android/node_modules/bplist-parser": {
@@ -13196,21 +13195,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/cordova-android/node_modules/fs-extra": {
-      "version": "11.3.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.0.tgz",
-      "integrity": "sha512-Z4XaCL6dUDHfP/jT25jJKMmtxvuwbkrD1vNSMFlo9lNLY2c5FHYSQgHPRZUjAB26TpDEoW9HCOgplrdbaPV/ew==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=14.14"
-      }
-    },
     "node_modules/cordova-android/node_modules/isexe": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-3.1.1.tgz",
@@ -13222,19 +13206,19 @@
       }
     },
     "node_modules/cordova-android/node_modules/nopt": {
-      "version": "7.2.1",
-      "resolved": "https://registry.npmjs.org/nopt/-/nopt-7.2.1.tgz",
-      "integrity": "sha512-taM24ViiimT/XntxbPyJQzCG+p4EKOpgD3mxFwW38mGjVUrfERQOeY4EDHjdnptttfHuHQXFx+lTP08Q+mLa/w==",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-8.1.0.tgz",
+      "integrity": "sha512-ieGu42u/Qsa4TFktmaKEwM6MQH0pOWnaB3htzh0JRtx84+Mebc0cbZYN5bC+6WTZ4+77xrL9Pn5m7CV6VIkV7A==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "abbrev": "^2.0.0"
+        "abbrev": "^3.0.0"
       },
       "bin": {
         "nopt": "bin/nopt.js"
       },
       "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+        "node": "^18.17.0 || >=20.5.0"
       }
     },
     "node_modules/cordova-android/node_modules/semver": {
@@ -13261,9 +13245,9 @@
       }
     },
     "node_modules/cordova-android/node_modules/which": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/which/-/which-4.0.0.tgz",
-      "integrity": "sha512-GlaYyEb07DPxYCKhKzplCWBJtvxZcZMrL+4UkrTSJHHPyZU4mYYTv3qaOe77H7EODLSSopAUFAc6W8U4yqvscg==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/which/-/which-5.0.0.tgz",
+      "integrity": "sha512-JEdGzHwwkrbWoGOlIHqQ5gtprKGOenpDHpxE9zVR1bWbOtYRyPPHMe9FaP6x61CmNaTThSkb0DAJte5jD+DmzQ==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -13273,7 +13257,7 @@
         "node-which": "bin/which.js"
       },
       "engines": {
-        "node": "^16.13.0 || >=18.0.0"
+        "node": "^18.17.0 || >=20.5.0"
       }
     },
     "node_modules/cordova-browser": {
@@ -39587,7 +39571,7 @@
         "chalk": "^5.0.1",
         "copy-dir": "^1.3.0",
         "copy-webpack-plugin": "^5.1.1",
-        "cordova-android": "^13.0.0",
+        "cordova-android": "^14.0.0",
         "cordova-browser": "~6.0.0",
         "cordova-ios": "github:apache/cordova-ios#1a5cd45e2243b239b5045a0ade9d2da1d779b72a",
         "cordova-lib": "^11.0.0",
@@ -46020,30 +46004,29 @@
       }
     },
     "cordova-android": {
-      "version": "13.0.0",
-      "resolved": "https://registry.npmjs.org/cordova-android/-/cordova-android-13.0.0.tgz",
-      "integrity": "sha512-uQG+cSyrB1NMi2aIzihldIupHB9WGpZVvrMMMAAtnyc6tDlEk7gweSSaFsEONyGAnteRYpIvrzg/YwDW08PcUg==",
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/cordova-android/-/cordova-android-14.0.1.tgz",
+      "integrity": "sha512-HMBMdGu/JlSQtmBuDEpKWf/pE75SpF3FksxZ+mqYuL3qSIN8lN/QsNurwYaPAP7zWXN2DNpvwlpOJItS5VhdLg==",
       "dev": true,
       "requires": {
-        "android-versions": "^2.0.0",
-        "cordova-common": "^5.0.0",
+        "android-versions": "^2.1.0",
+        "cordova-common": "^5.0.1",
         "dedent": "^1.5.3",
         "execa": "^5.1.1",
-        "fast-glob": "^3.3.2",
-        "fs-extra": "^11.2.0",
+        "fast-glob": "^3.3.3",
         "is-path-inside": "^3.0.3",
-        "nopt": "^7.2.1",
+        "nopt": "^8.1.0",
         "properties-parser": "^0.6.0",
-        "semver": "^7.6.2",
+        "semver": "^7.7.1",
         "string-argv": "^0.3.1",
         "untildify": "^4.0.0",
-        "which": "^4.0.0"
+        "which": "^5.0.0"
       },
       "dependencies": {
         "abbrev": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-2.0.0.tgz",
-          "integrity": "sha512-6/mh1E2u2YgEsCHdY0Yx5oW+61gZU+1vXaoiHHrpKeuRNNgFvS+/jrwHiQhB5apAf5oB7UB7E19ol2R2LKH8hQ==",
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-3.0.1.tgz",
+          "integrity": "sha512-AO2ac6pjRB3SJmGJo+v5/aK6Omggp6fsLrs6wN9bd35ulu4cCwaAU9+7ZhXjeqHVkaHThLuzH0nZr0YpCDhygg==",
           "dev": true
         },
         "bplist-parser": {
@@ -46101,17 +46084,6 @@
             }
           }
         },
-        "fs-extra": {
-          "version": "11.3.0",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.0.tgz",
-          "integrity": "sha512-Z4XaCL6dUDHfP/jT25jJKMmtxvuwbkrD1vNSMFlo9lNLY2c5FHYSQgHPRZUjAB26TpDEoW9HCOgplrdbaPV/ew==",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "^4.2.0",
-            "jsonfile": "^6.0.1",
-            "universalify": "^2.0.0"
-          }
-        },
         "isexe": {
           "version": "3.1.1",
           "resolved": "https://registry.npmjs.org/isexe/-/isexe-3.1.1.tgz",
@@ -46119,12 +46091,12 @@
           "dev": true
         },
         "nopt": {
-          "version": "7.2.1",
-          "resolved": "https://registry.npmjs.org/nopt/-/nopt-7.2.1.tgz",
-          "integrity": "sha512-taM24ViiimT/XntxbPyJQzCG+p4EKOpgD3mxFwW38mGjVUrfERQOeY4EDHjdnptttfHuHQXFx+lTP08Q+mLa/w==",
+          "version": "8.1.0",
+          "resolved": "https://registry.npmjs.org/nopt/-/nopt-8.1.0.tgz",
+          "integrity": "sha512-ieGu42u/Qsa4TFktmaKEwM6MQH0pOWnaB3htzh0JRtx84+Mebc0cbZYN5bC+6WTZ4+77xrL9Pn5m7CV6VIkV7A==",
           "dev": true,
           "requires": {
-            "abbrev": "^2.0.0"
+            "abbrev": "^3.0.0"
           }
         },
         "semver": {
@@ -46140,9 +46112,9 @@
           "dev": true
         },
         "which": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/which/-/which-4.0.0.tgz",
-          "integrity": "sha512-GlaYyEb07DPxYCKhKzplCWBJtvxZcZMrL+4UkrTSJHHPyZU4mYYTv3qaOe77H7EODLSSopAUFAc6W8U4yqvscg==",
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/which/-/which-5.0.0.tgz",
+          "integrity": "sha512-JEdGzHwwkrbWoGOlIHqQ5gtprKGOenpDHpxE9zVR1bWbOtYRyPPHMe9FaP6x61CmNaTThSkb0DAJte5jD+DmzQ==",
           "dev": true,
           "requires": {
             "isexe": "^3.1.1"


### PR DESCRIPTION
Updating:
- android API: 34 (14.0) -> 35 (15.0)
- cordova android: 13.0.0 -> 14.0.0 https://cordova.apache.org/docs/en/dev/guide/platforms/android/index.html (14.0.0 is considered `dev`)
- android gradle plugin: 8.3.0 -> 8.7.3

Tested:
Installed a build on my phone with adb and was able to connect through canary. (Also dark mode looks very nice!)