### PR TITLE
chore(client): clean up client config

### DIFF
--- a/client/electron/tunnel_store.ts
+++ b/client/electron/tunnel_store.ts
@@ -83,5 +83,5 @@ export class TunnelStore {
 
 // Returns whether `tunnel` and its configuration contain all the required fields.
 function isRequestValid(request: StartRequestJson) {
-  return request.id && request.config;
+  return request.id && request.client;
 }

--- a/client/electron/vpn_service.ts
+++ b/client/electron/vpn_service.ts
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 import {invokeGoMethod, registerCallback} from './go_plugin';
-import {FirstHopAndTunnelConfigJson} from '../src/www/app/outline_server_repository/config';
 import {
   StartRequestJson,
   TunnelStatus,
@@ -31,12 +30,13 @@ interface VpnConfig {
   protectionMark: number;
 }
 
-interface EstablishVpnRequest extends FirstHopAndTunnelConfigJson {
+interface EstablishVpnRequestJson {
   vpn: VpnConfig;
+  client: string;
 }
 
 export async function establishVpn(tsRequest: StartRequestJson) {
-  const goRequest: EstablishVpnRequest = {
+  const goRequest: EstablishVpnRequestJson = {
     // The following VPN configuration ensures that the new routing can co-exist with any legacy Outline routings (e.g. AppImage).
     vpn: {
       id: tsRequest.id,
@@ -63,8 +63,8 @@ export async function establishVpn(tsRequest: StartRequestJson) {
       protectionMark: 0x711e,
     },
 
-    // The actual tunnel config
-    ...tsRequest.config,
+    // The actual client config
+    client: tsRequest.client,
   };
 
   // The request looks like:

--- a/client/go/outline/vpn_linux.go
+++ b/client/go/outline/vpn_linux.go
@@ -24,7 +24,7 @@ import (
 	"github.com/Jigsaw-Code/outline-apps/client/go/outline/vpn"
 )
 
-// establishVpnRequestJSON must match Typescript's EstablishVpnRequestJson.
+// establishVpnRequestJSON must match TypeScript's EstablishVpnRequestJson.
 type establishVpnRequestJSON struct {
 	Client string     `json:"client"`
 	VPN    vpn.Config `json:"vpn"`

--- a/client/go/outline/vpn_linux.go
+++ b/client/go/outline/vpn_linux.go
@@ -24,9 +24,10 @@ import (
 	"github.com/Jigsaw-Code/outline-apps/client/go/outline/vpn"
 )
 
-type vpnConfigJSON struct {
-	firstHopAndTunnelConfigJSON `json:",inline"`
-	VPNConfig                   vpn.Config `json:"vpn"`
+// establishVpnRequestJSON must match Typescript's EstablishVpnRequestJson.
+type establishVpnRequestJSON struct {
+	Client string     `json:"client"`
+	VPN    vpn.Config `json:"vpn"`
 }
 
 // establishVPN establishes a VPN connection using the given configuration string.
@@ -35,7 +36,7 @@ type vpnConfigJSON struct {
 //
 // The function returns a non-nil error if the connection fails.
 func establishVPN(configStr string) error {
-	var conf vpnConfigJSON
+	var conf establishVpnRequestJSON
 	if err := json.Unmarshal([]byte(configStr), &conf); err != nil {
 		return perrs.PlatformError{
 			Code:    perrs.InvalidConfig,
@@ -44,14 +45,14 @@ func establishVPN(configStr string) error {
 		}
 	}
 
-	tcp := newFWMarkProtectedTCPDialer(conf.VPNConfig.ProtectionMark)
-	udp := newFWMarkProtectedUDPDialer(conf.VPNConfig.ProtectionMark)
+	tcp := newFWMarkProtectedTCPDialer(conf.VPN.ProtectionMark)
+	udp := newFWMarkProtectedUDPDialer(conf.VPN.ProtectionMark)
 	c, err := NewClientWithBaseDialers(conf.Client, tcp, udp)
 	if err != nil {
 		return err
 	}
 
-	_, err = vpn.EstablishVPN(context.Background(), &conf.VPNConfig, c, c)
+	_, err = vpn.EstablishVPN(context.Background(), &conf.VPN, c, c)
 	return err
 }
 

--- a/client/src/www/app/outline_server_repository/config.spec.ts
+++ b/client/src/www/app/outline_server_repository/config.spec.ts
@@ -29,14 +29,14 @@ describe('parseAccessKey', () => {
   });
 
   it('extracts name from ss:// key', async () => {
-    const transportConfig = `ss://${encodeURIComponent(
+    const clientConfig = `ss://${encodeURIComponent(
       btoa('chacha20-ietf-poly1305:SECRET')
     )}@example.com:4321`;
-    const accessKey = `${transportConfig}#My%20Server`;
+    const accessKey = `${clientConfig}#My%20Server`;
     expect(await config.parseAccessKey(accessKey)).toEqual(
       new config.StaticServiceConfig('My Server', {
         firstHop: 'first-hop:4321',
-        transport: transportConfig,
+        client: clientConfig,
       })
     );
   });
@@ -53,12 +53,12 @@ describe('parseAccessKey', () => {
   });
 
   it('name extraction ignores parameters', async () => {
-    const transportConfig = 'ss://anything';
-    const accessKey = `${transportConfig}#foo=bar&My%20Server&baz=boo`;
+    const clientConfig = 'ss://anything';
+    const accessKey = `${clientConfig}#foo=bar&My%20Server&baz=boo`;
     expect(await config.parseAccessKey(accessKey)).toEqual(
       new config.StaticServiceConfig('My Server', {
         firstHop: 'first-hop:4321',
-        transport: transportConfig,
+        client: clientConfig,
       })
     );
   });

--- a/client/src/www/app/outline_server_repository/config.spec.ts
+++ b/client/src/www/app/outline_server_repository/config.spec.ts
@@ -24,7 +24,7 @@ describe('parseAccessKey', () => {
       if (params.indexOf('invalid') > -1) {
         throw Error('fake invalid config');
       }
-      return `{"transport": ${JSON.stringify(params)}, "firstHop": "first-hop:4321"}`;
+      return `{"client": ${JSON.stringify(params)}, "firstHop": "first-hop:4321"}`;
     },
   });
 
@@ -34,10 +34,7 @@ describe('parseAccessKey', () => {
     )}@example.com:4321`;
     const accessKey = `${clientConfig}#My%20Server`;
     expect(await config.parseAccessKey(accessKey)).toEqual(
-      new config.StaticServiceConfig('My Server', {
-        firstHop: 'first-hop:4321',
-        client: clientConfig,
-      })
+      new config.StaticServiceConfig('My Server', 'first-hop:4321', clientConfig)
     );
   });
 
@@ -56,10 +53,7 @@ describe('parseAccessKey', () => {
     const clientConfig = 'ss://anything';
     const accessKey = `${clientConfig}#foo=bar&My%20Server&baz=boo`;
     expect(await config.parseAccessKey(accessKey)).toEqual(
-      new config.StaticServiceConfig('My Server', {
-        firstHop: 'first-hop:4321',
-        client: clientConfig,
-      })
+      new config.StaticServiceConfig('My Server', 'first-hop:4321', clientConfig)
     );
   });
 });

--- a/client/src/www/app/outline_server_repository/config.spec.ts
+++ b/client/src/www/app/outline_server_repository/config.spec.ts
@@ -34,7 +34,11 @@ describe('parseAccessKey', () => {
     )}@example.com:4321`;
     const accessKey = `${clientConfig}#My%20Server`;
     expect(await config.parseAccessKey(accessKey)).toEqual(
-      new config.StaticServiceConfig('My Server', 'first-hop:4321', clientConfig)
+      new config.StaticServiceConfig(
+        'My Server',
+        'first-hop:4321',
+        clientConfig
+      )
     );
   });
 
@@ -53,7 +57,11 @@ describe('parseAccessKey', () => {
     const clientConfig = 'ss://anything';
     const accessKey = `${clientConfig}#foo=bar&My%20Server&baz=boo`;
     expect(await config.parseAccessKey(accessKey)).toEqual(
-      new config.StaticServiceConfig('My Server', 'first-hop:4321', clientConfig)
+      new config.StaticServiceConfig(
+        'My Server',
+        'first-hop:4321',
+        clientConfig
+      )
     );
   });
 });

--- a/client/src/www/app/outline_server_repository/config.ts
+++ b/client/src/www/app/outline_server_repository/config.ts
@@ -29,7 +29,8 @@ export type ServiceConfig = StaticServiceConfig | DynamicServiceConfig;
 export class StaticServiceConfig {
   constructor(
     readonly name: string,
-    readonly tunnelConfig: FirstHopAndTunnelConfigJson
+    readonly firstHop: string,
+    readonly client: string
   ) {}
 }
 
@@ -90,10 +91,8 @@ export async function parseAccessKey(
 
     // Static ss:// keys. It encodes the full service config.
     if (noHashAccessKey.protocol === 'ss:') {
-      return new StaticServiceConfig(
-        name,
-        await parseTunnelConfig(noHashAccessKey.toString())
-      );
+      const parsed = await parseTunnelConfig(noHashAccessKey.toString());
+      return new StaticServiceConfig(name, parsed.firstHop, parsed.client);
     }
 
     // Dynamic ssconf:// keys. It encodes the location of the service config.

--- a/client/src/www/app/outline_server_repository/server.ts
+++ b/client/src/www/app/outline_server_repository/server.ts
@@ -97,7 +97,7 @@ class OutlineServer implements Server {
         id: this.id,
         name: this.name,
         firstHop: this.tunnelConfig.firstHop,
-        client: this.tunnelConfig.client
+        client: this.tunnelConfig.client,
       };
       await this.vpnApi.start(request);
     } catch (cause) {

--- a/client/src/www/app/outline_server_repository/server.ts
+++ b/client/src/www/app/outline_server_repository/server.ts
@@ -96,7 +96,8 @@ class OutlineServer implements Server {
       const request: StartRequestJson = {
         id: this.id,
         name: this.name,
-        config: this.tunnelConfig,
+        firstHop: this.tunnelConfig.firstHop,
+        client: this.tunnelConfig.client
       };
       await this.vpnApi.start(request);
     } catch (cause) {

--- a/client/src/www/app/outline_server_repository/server.ts
+++ b/client/src/www/app/outline_server_repository/server.ts
@@ -68,7 +68,7 @@ export async function newOutlineServer(
 
 class OutlineServer implements Server {
   errorMessageId?: string;
-  private tunnelConfig?: FirstHopAndTunnelConfigJson;
+  private startRequest: StartRequestJson;
 
   constructor(
     private vpnApi: VpnApi,
@@ -77,29 +77,34 @@ class OutlineServer implements Server {
     private serviceConfig: ServiceConfig
   ) {
     if (serviceConfig instanceof StaticServiceConfig) {
-      this.tunnelConfig = serviceConfig.tunnelConfig;
+      this.startRequest = {
+        id,
+        name,
+        firstHop: serviceConfig.firstHop,
+        client: serviceConfig.client,
+      };
     }
   }
 
   get address() {
-    return this.tunnelConfig?.firstHop || '';
+    return this.startRequest?.firstHop || '';
   }
 
   async connect() {
     if (this.serviceConfig instanceof DynamicServiceConfig) {
-      this.tunnelConfig = await fetchTunnelConfig(
+      const {firstHop, client} = await fetchTunnelConfig(
         this.serviceConfig.transportConfigLocation
       );
+      this.startRequest = {
+        id: this.id,
+        name: this.name,
+        firstHop,
+        client,
+      };
     }
 
     try {
-      const request: StartRequestJson = {
-        id: this.id,
-        name: this.name,
-        firstHop: this.tunnelConfig.firstHop,
-        client: this.tunnelConfig.client,
-      };
-      await this.vpnApi.start(request);
+      await this.vpnApi.start(this.startRequest);
     } catch (cause) {
       // TODO(junyi): Remove the catch above once all platforms are migrated to PlatformError
       if (cause instanceof PlatformError) {
@@ -124,7 +129,7 @@ class OutlineServer implements Server {
       await this.vpnApi.stop(this.id);
 
       if (this.serviceConfig instanceof DynamicServiceConfig) {
-        this.tunnelConfig = undefined;
+        this.startRequest = undefined;
       }
     } catch {
       // All the plugins treat disconnection errors as ErrorCode.UNEXPECTED.

--- a/client/src/www/app/outline_server_repository/vpn.cordova.ts
+++ b/client/src/www/app/outline_server_repository/vpn.cordova.ts
@@ -20,7 +20,7 @@ export class CordovaVpnApi implements VpnApi {
   constructor() {}
 
   start(request: StartRequestJson) {
-    if (!request.config) {
+    if (!request.client) {
       throw new errors.IllegalServerConfiguration();
     }
     return pluginExec<void>(
@@ -28,7 +28,7 @@ export class CordovaVpnApi implements VpnApi {
       // TODO(fortuna): Make the Cordova plugin take a StartRequestJson.
       request.id,
       request.name,
-      request.config.client
+      request.client
     );
   }
 

--- a/client/src/www/app/outline_server_repository/vpn.fake.ts
+++ b/client/src/www/app/outline_server_repository/vpn.fake.ts
@@ -39,7 +39,7 @@ export class FakeVpnApi implements VpnApi {
       return;
     }
 
-    const address = request.config.firstHop;
+    const address = request.firstHop;
     if (this.playUnreachable(address)) {
       throw new errors.OutlinePluginError(errors.ErrorCode.SERVER_UNREACHABLE);
     } else if (this.playBroken(address)) {

--- a/client/src/www/app/outline_server_repository/vpn.ts
+++ b/client/src/www/app/outline_server_repository/vpn.ts
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {FirstHopAndTunnelConfigJson} from './config';
-
 export const enum TunnelStatus {
   CONNECTED,
   DISCONNECTED,
@@ -25,7 +23,10 @@ export const enum TunnelStatus {
 export interface StartRequestJson {
   id: string;
   name: string;
-  config: FirstHopAndTunnelConfigJson;
+  // Client config, ultimately passed to NewClient in Go.
+  client: string;
+  // First hop used by the legacy Electron code.
+  firstHop: string;
 }
 
 /** VpnApi is how we talk to the platform-specific VPN API. */

--- a/client/tsconfig.json
+++ b/client/tsconfig.json
@@ -14,8 +14,17 @@
     "rootDir": "../",
     "skipLibCheck": true,
     "target": "es2017",
-    "lib": ["es2022"]
+    "lib": [
+      "es2022"
+    ]
   },
-  "exclude": ["*.cjs", "*.js", "*.mjs", "**/*.spec.ts"],
-  "include": ["src", "electron"]
+  "exclude": [
+    "*.cjs",
+    "*.js",
+    "*.mjs"
+  ],
+  "include": [
+    "src",
+    "electron"
+  ]
 }


### PR DESCRIPTION
- Minimize use of `FirstHopAndTunnelConfigJson`
- Use `clientConfig` instead of `tunnelConfig`/`transportConfig` consistently.
- Stop using `config` as a field name. It's meaningless.

/cc @emohandesi @62w71st 