### PR TITLE
feat(client): add usage report config

### DIFF
--- a/client/config.md
+++ b/client/config.md
@@ -145,6 +145,26 @@ transport:
     secret: SS_SECRET
 ```
 
+In case the count of users is needed to have an exact estimate of the sessions, a reporting server can be used for that. This feature is currently experimental.
+
+```yaml
+transport:
+  $type: tcpudp
+  tcp:
+    <<: &shared
+      $type: shadowsocks
+      endpoint: ss.example.com:4321
+      cipher: chacha20-ietf-poly1305
+      secret: SECRET
+    prefix: "POST "
+  udp: *shared
+
+reporter:
+  $type: http
+  url: https://your-callback-server.com/outline_callback
+  interval: 24h
+```
+
 ## Tunnels
 
 ### <a id=TunnelConfig></a>TunnelConfig

--- a/client/go/outline/client.go
+++ b/client/go/outline/client.go
@@ -17,12 +17,16 @@ package outline
 import (
 	"context"
 	"errors"
+	"fmt"
 	"log/slog"
 	"net"
+	"net/http"
+	"strings"
 
 	"github.com/Jigsaw-Code/outline-apps/client/go/configyaml"
 	"github.com/Jigsaw-Code/outline-apps/client/go/outline/config"
 	"github.com/Jigsaw-Code/outline-apps/client/go/outline/platerrors"
+	"github.com/Jigsaw-Code/outline-apps/client/go/outline/reporting"
 	"github.com/Jigsaw-Code/outline-sdk/transport"
 	"github.com/goccy/go-yaml"
 )
@@ -36,8 +40,10 @@ import (
 //     to handle that.
 //   - Refactor so that StartSession returns a Client
 type Client struct {
-	sd *config.Dialer[transport.StreamConn]
-	pl *config.PacketListener
+	sd            *config.Dialer[transport.StreamConn]
+	pl            *config.PacketListener
+	reporter      reporting.Reporter
+	sessionCancel context.CancelFunc
 }
 
 func (c *Client) DialStream(ctx context.Context, address string) (transport.StreamConn, error) {
@@ -50,17 +56,22 @@ func (c *Client) ListenPacket(ctx context.Context) (net.PacketConn, error) {
 
 func (c *Client) StartSession() error {
 	slog.Debug("Starting session")
+	var sessionCtx context.Context
+	sessionCtx, c.sessionCancel = context.WithCancel(context.Background())
+	go c.reporter.Run(sessionCtx)
 	return nil
 }
 
 func (c *Client) EndSession() error {
 	slog.Debug("Ending session")
+	c.sessionCancel()
 	return nil
 }
 
 // ClientConfig is used to create the Client.
 type ClientConfig struct {
 	Transport configyaml.ConfigNode
+	Reporter  configyaml.ConfigNode
 }
 
 // NewClientResult represents the result of [NewClientAndReturnError].
@@ -124,5 +135,38 @@ func NewClientWithBaseDialers(clientConfigText string, tcpDialer transport.Strea
 		}
 	}
 
-	return &Client{sd: transportPair.StreamDialer, pl: transportPair.PacketListener}, nil
+	client := &Client{sd: transportPair.StreamDialer, pl: transportPair.PacketListener}
+	if clientConfig.Reporter != nil {
+		httpClient := &http.Client{
+			Transport: &http.Transport{
+				DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
+					if strings.HasPrefix(network, "tcp") {
+						return client.DialStream(ctx, addr)
+					} else {
+						return nil, fmt.Errorf("protocol not supported: %v", network)
+					}
+				},
+			},
+		}
+		reporter, err := NewReporterParser(httpClient).Parse(context.Background(), clientConfig.Reporter)
+		if err != nil {
+			return nil, &platerrors.PlatformError{
+				Code:    platerrors.InvalidConfig,
+				Message: "invalid reporter config",
+				Cause:   platerrors.ToPlatformError(err),
+			}
+		}
+		client.reporter = reporter
+	}
+
+	return client, nil
+}
+
+func NewReporterParser(httpClient *http.Client) *configyaml.TypeParser[reporting.Reporter] {
+	parser := configyaml.NewTypeParser(func(ctx context.Context, input configyaml.ConfigNode) (reporting.Reporter, error) {
+		return nil, errors.New("parser not specified")
+	})
+	parser.RegisterSubParser("first-supported", config.NewFirstSupportedSubParser(parser.Parse))
+	parser.RegisterSubParser("http", reporting.NewHTTPReporterSubParser(httpClient))
+	return parser
 }

--- a/client/go/outline/reporting/client.go
+++ b/client/go/outline/reporting/client.go
@@ -1,0 +1,70 @@
+// Copyright 2025 The Outline Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package reporting
+
+import (
+	"context"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"time"
+)
+
+// Reporter is used to register reports.
+type Reporter interface {
+	// Run blocks until the session context is done.
+	Run(sessionCtx context.Context)
+}
+
+type HTTPReporter struct {
+	URL        url.URL
+	Interval   time.Duration
+	HttpClient *http.Client
+}
+
+func (r *HTTPReporter) Run(sessionCtx context.Context) {
+	r.Report()
+	ticker := time.NewTicker(r.Interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-sessionCtx.Done():
+			return
+		case _, ok := <-ticker.C:
+			if !ok {
+				return
+			}
+			r.Report()
+		}
+	}
+}
+
+func (r *HTTPReporter) Report() {
+	slog.Debug("Sending report", "url", r.URL.String())
+
+	req, err := http.NewRequest("POST", r.URL.String(), nil)
+	if err != nil {
+		slog.Warn("Failed to create report HTTP request", "err", err)
+		return
+	}
+	req.Close = true
+
+	resp, err := r.HttpClient.Do(req)
+	if err != nil {
+		slog.Warn("Failed to send report", "err", err)
+		return
+	}
+	resp.Body.Close()
+}

--- a/client/go/outline/reporting/client_test.go
+++ b/client/go/outline/reporting/client_test.go
@@ -1,0 +1,79 @@
+// Copyright 2025 The Outline Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package reporting
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestHTTPReporter_Report(t *testing.T) {
+	var receivedRequest *http.Request
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedRequest = r
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	serverURL, err := url.Parse(server.URL)
+	if err != nil {
+		t.Fatalf("Failed to parse server URL: %v", err)
+	}
+
+	reporter := &HTTPReporter{
+		URL:        *serverURL,
+		HttpClient: server.Client(),
+	}
+
+	reporter.Report()
+
+	require.NotNil(t, receivedRequest, "Server did not receive the request")
+	require.Equal(t, "POST", receivedRequest.Method)
+}
+
+func TestHTTPReporter_ReportInterval(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	serverURL, err := url.Parse(server.URL)
+	if err != nil {
+		t.Fatalf("Failed to parse server URL: %v", err)
+	}
+
+	reporter := &HTTPReporter{
+		URL:        *serverURL,
+		HttpClient: server.Client(),
+		Interval:   100 * time.Millisecond,
+	}
+
+	sessionCtx, cancelSession := context.WithCancel(context.Background())
+
+	go reporter.Run(sessionCtx)
+
+	time.Sleep(450 * time.Millisecond)
+	cancelSession()
+
+	require.Equal(t, 5, requestCount)
+}

--- a/client/go/outline/reporting/config.go
+++ b/client/go/outline/reporting/config.go
@@ -1,0 +1,59 @@
+// Copyright 2025 The Outline Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package reporting
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+	"time"
+
+	"github.com/Jigsaw-Code/outline-apps/client/go/configyaml"
+)
+
+// HTTPReporterConfig is the format for the HTTPReporter config.
+type HTTPReporterConfig struct {
+	URL      string
+	Interval string
+}
+
+func NewHTTPReporterSubParser(httpClient *http.Client) func(ctx context.Context, input map[string]any) (Reporter, error) {
+	return func(ctx context.Context, input map[string]any) (Reporter, error) {
+		var config HTTPReporterConfig
+		if err := configyaml.MapToAny(input, &config); err != nil {
+			return nil, fmt.Errorf("invalid config format: %w", err)
+		}
+
+		collectorURL, err := url.Parse(config.URL)
+		if err != nil {
+			return nil, fmt.Errorf("failed to report collector URL: %w", err)
+		}
+		reporter := &HTTPReporter{URL: *collectorURL, HttpClient: httpClient}
+
+		if config.Interval != "" {
+			interval, err := time.ParseDuration(config.Interval)
+			if err != nil {
+				return nil, fmt.Errorf("failed to parse interval: %w", err)
+			}
+			if interval <= 0 {
+				return nil, fmt.Errorf("tunnel usage interval must be greater than 0")
+			}
+			reporter.Interval = interval
+		}
+
+		return reporter, nil
+	}
+}


### PR DESCRIPTION
This PR adds support for usage reporting. The config format looks like this:

```yaml
transport:
  $type: tcpudp
  tcp:
      $type: shadowsocks
      endpoint: example.com:80
      <<: &cipher
        cipher: chacha20-ietf-poly1305
        secret: SECRET
      prefix: "POST "
  udp:
      $type: shadowsocks
      endpoint: example.com:53
      <<: *cipher

reporter:
  $type: http
  url: https://your-callback-server.com/outline_callback
  interval: 1h
```

The `http` reporter will send a POST request to the given URL at the beginning of the session, and then every `interval`.

/cc @emohandesi @62w71st 

