### PR TITLE
fix(client): fix dark mode textfield in server rename dialog

### DIFF
--- a/client/src/www/views/servers_view/server_list_item/server_card/server_rename_dialog/index.ts
+++ b/client/src/www/views/servers_view/server_list_item/server_card/server_rename_dialog/index.ts
@@ -49,14 +49,15 @@ export class ServerRenameDialog extends LitElement {
     }
 
     mwc-textfield {
-      --mdc-text-field-fill-color: var(--outline-input-bg);
+      --mdc-text-field-fill-color: transparent;
       --mdc-text-field-ink-color: var(--outline-input-text);
       --mdc-text-field-label-ink-color: var(--outline-label-color);
       --mdc-text-field-outlined-idle-border-color: var(--outline-input-border);
       --mdc-theme-primary: var(--outline-primary);
-      background-color: var(--outline-input-bg);
       color: var(--outline-input-text);
       border-radius: 4px;
+      display: block;
+      margin: 0 auto;
     }
   `;
 


### PR DESCRIPTION
Closes https://github.com/Jigsaw-Code/outline-apps/issues/2589


Moved the text field to centre
Light mode colour styling was not changed

Dark mode changes: 

Before: 
<img width="1179" height="2556" alt="53049" src="https://github.com/user-attachments/assets/909c1347-d288-4bd0-b13d-4c0fa3381d1d" />


After: 
<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 16 Pro - 2025-08-15 at 09 54 44" src="https://github.com/user-attachments/assets/686ca681-99e3-46ec-873e-e90ed1003ac3" />

Removed the background to keep it consistent with light mode (there's no bg for the input)