### PR TITLE
fix(client): remove redundant connection status menu item

### DIFF
--- a/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/en.lproj/Localizable.strings
+++ b/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/en.lproj/Localizable.strings
@@ -1,5 +1,3 @@
-"connected_server_state" = "Connected";
-"disconnected_server_state" = "Disconnected";
 "tray_open_window" = "Open";
 "quit" = "Quit";
 "disconnect" = "Disconnect";

--- a/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/StatusItemController.swift
+++ b/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/StatusItemController.swift
@@ -25,9 +25,6 @@ public enum ConnectionStatus: Int {
 var StatusItem = NSStatusItem()
 
 class StatusItemController: NSObject {
-    let connectionStatusMenuItem = NSMenuItem(title: MenuTitle.statusDisconnected,
-                                              action: nil,
-                                              keyEquivalent: "")
     let connectDisconnectMenuItem = NSMenuItem(title: MenuTitle.connect,
                                                action: #selector(toggleVpnConnection),
                                                keyEquivalent: "c")
@@ -47,16 +44,6 @@ class StatusItemController: NSObject {
             "quit",
             bundle: Bundle(for: StatusItemController.self),
             comment: "Tray menu entry to quit the application."
-        )
-        static let statusConnected = NSLocalizedString(
-            "connected_server_state",
-            bundle: Bundle(for: StatusItemController.self),
-            comment: "Tray menu entry indicating a server is currently connected and in use."
-        )
-        static let statusDisconnected = NSLocalizedString(
-            "disconnected_server_state",
-            bundle: Bundle(for: StatusItemController.self),
-            comment: "Tray menu entry indicating no server is currently connected."
         )
         static let connect = NSLocalizedString(
             "connect",
@@ -81,7 +68,6 @@ class StatusItemController: NSObject {
         let openMenuItem = NSMenuItem(title: MenuTitle.open, action: #selector(openApplication), keyEquivalent: "o")
         openMenuItem.target = self
         menu.addItem(openMenuItem)
-        menu.addItem(connectionStatusMenuItem)
         menu.addItem(NSMenuItem.separator())
         connectDisconnectMenuItem.target = self
         menu.addItem(connectDisconnectMenuItem)
@@ -99,9 +85,6 @@ class StatusItemController: NSObject {
         appIconImage.isTemplate = true
         StatusItem.button?.image = appIconImage
 
-        let connectionStatusTitle = isConnected ? MenuTitle.statusConnected : MenuTitle.statusDisconnected
-        connectionStatusMenuItem.title = connectionStatusTitle
-        
         // Update connect/disconnect menu item
         let connectDisconnectTitle = isConnected ? MenuTitle.disconnect : MenuTitle.connect
         connectDisconnectMenuItem.title = connectDisconnectTitle


### PR DESCRIPTION
<img width="286" height="278" alt="5489" src="https://github.com/user-attachments/assets/904e1906-4437-4d5f-b481-8e658448a6fc" />

Removes the `Connected` and `Disconnected` titles in the menubar. https://github.com/Jigsaw-Code/outline-apps/pull/2523 adds the ability to `Connect` and `Disconnect` from the menu bar already and having a status text is redundant and unnecessary as mentioned [here](https://github.com/Jigsaw-Code/outline-apps/pull/2523#issuecomment-3190580281)

