### PR TITLE
feat: Replace PacketListener with PacketProxy and refactor packetConn

### DIFF
--- a/client/go/outline/client_test.go
+++ b/client/go/outline/client_test.go
@@ -32,8 +32,8 @@ func Test_NewTransport_SS_URL(t *testing.T) {
 
 	result := NewClient(config)
 	require.Nil(t, result.Error, "Got %v", result.Error)
-	require.Equal(t, firstHop, result.Client.sd.FirstHop)
-	require.Equal(t, firstHop, result.Client.pl.FirstHop)
+	require.Equal(t, firstHop, result.Client.transportPair.StreamDialer.FirstHop)
+	require.Equal(t, firstHop, result.Client.transportPair.PacketProxy.FirstHop)
 }
 
 func Test_NewTransport_Legacy_JSON(t *testing.T) {
@@ -48,8 +48,8 @@ transport: {
 
 	result := NewClient(config)
 	require.Nil(t, result.Error, "Got %v", result.Error)
-	require.Equal(t, firstHop, result.Client.sd.FirstHop)
-	require.Equal(t, firstHop, result.Client.pl.FirstHop)
+	require.Equal(t, firstHop, result.Client.transportPair.StreamDialer.FirstHop)
+	require.Equal(t, firstHop, result.Client.transportPair.PacketProxy.FirstHop)
 }
 
 func Test_NewTransport_Flexible_JSON(t *testing.T) {
@@ -65,8 +65,8 @@ transport: {
 
 	result := NewClient(config)
 	require.Nil(t, result.Error, "Got %v", result.Error)
-	require.Equal(t, firstHop, result.Client.sd.FirstHop)
-	require.Equal(t, firstHop, result.Client.pl.FirstHop)
+	require.Equal(t, firstHop, result.Client.transportPair.StreamDialer.FirstHop)
+	require.Equal(t, firstHop, result.Client.transportPair.PacketProxy.FirstHop)
 }
 
 func Test_NewTransport_YAML(t *testing.T) {
@@ -81,8 +81,8 @@ transport:
 
 	result := NewClient(config)
 	require.Nil(t, result.Error, "Got %v", result.Error)
-	require.Equal(t, firstHop, result.Client.sd.FirstHop)
-	require.Equal(t, firstHop, result.Client.pl.FirstHop)
+	require.Equal(t, firstHop, result.Client.transportPair.StreamDialer.FirstHop)
+	require.Equal(t, firstHop, result.Client.transportPair.PacketProxy.FirstHop)
 }
 
 func Test_NewTransport_Explicit_endpoint(t *testing.T) {
@@ -97,8 +97,8 @@ transport:
 
 	result := NewClient(config)
 	require.Nil(t, result.Error, "Got %v", result.Error)
-	require.Equal(t, firstHop, result.Client.sd.FirstHop)
-	require.Equal(t, firstHop, result.Client.pl.FirstHop)
+	require.Equal(t, firstHop, result.Client.transportPair.StreamDialer.FirstHop)
+	require.Equal(t, firstHop, result.Client.transportPair.PacketProxy.FirstHop)
 }
 
 func Test_NewTransport_Multihop_URL(t *testing.T) {
@@ -114,8 +114,8 @@ transport:
 
 	result := NewClient(config)
 	require.Nil(t, result.Error, "Got %v", result.Error)
-	require.Equal(t, firstHop, result.Client.sd.FirstHop)
-	require.Equal(t, firstHop, result.Client.pl.FirstHop)
+	require.Equal(t, firstHop, result.Client.transportPair.StreamDialer.FirstHop)
+	require.Equal(t, firstHop, result.Client.transportPair.PacketProxy.FirstHop)
 }
 
 func Test_NewTransport_Multihop_Explicit(t *testing.T) {
@@ -135,8 +135,8 @@ transport:
 
 	result := NewClient(config)
 	require.Nil(t, result.Error, "Got %v", result.Error)
-	require.Equal(t, firstHop, result.Client.sd.FirstHop)
-	require.Equal(t, firstHop, result.Client.pl.FirstHop)
+	require.Equal(t, firstHop, result.Client.transportPair.StreamDialer.FirstHop)
+	require.Equal(t, firstHop, result.Client.transportPair.PacketProxy.FirstHop)
 }
 
 func Test_NewTransport_Explicit_TCPUDP(t *testing.T) {
@@ -157,8 +157,8 @@ transport:
 
 	result := NewClient(config)
 	require.Nil(t, result.Error, "Got %v", result.Error)
-	require.Equal(t, "example.com:80", result.Client.sd.FirstHop)
-	require.Equal(t, "example.com:53", result.Client.pl.FirstHop)
+	require.Equal(t, "example.com:80", result.Client.transportPair.StreamDialer.FirstHop)
+	require.Equal(t, "example.com:53", result.Client.transportPair.PacketProxy.FirstHop)
 }
 
 func Test_NewTransport_YAML_Reuse(t *testing.T) {
@@ -177,8 +177,8 @@ transport:
 
 	result := NewClient(config)
 	require.Nil(t, result.Error, "Got %v", result.Error)
-	require.Equal(t, firstHop, result.Client.sd.FirstHop)
-	require.Equal(t, firstHop, result.Client.pl.FirstHop)
+	require.Equal(t, firstHop, result.Client.transportPair.StreamDialer.FirstHop)
+	require.Equal(t, firstHop, result.Client.transportPair.PacketProxy.FirstHop)
 }
 
 func Test_NewTransport_YAML_Partial_Reuse(t *testing.T) {
@@ -199,8 +199,8 @@ transport:
 
 	result := NewClient(config)
 	require.Nil(t, result.Error, "Got %v", result.Error)
-	require.Equal(t, "example.com:80", result.Client.sd.FirstHop)
-	require.Equal(t, "example.com:53", result.Client.pl.FirstHop)
+	require.Equal(t, "example.com:80", result.Client.transportPair.StreamDialer.FirstHop)
+	require.Equal(t, "example.com:53", result.Client.transportPair.PacketProxy.FirstHop)
 }
 
 func Test_NewTransport_Unsupported(t *testing.T) {
@@ -230,8 +230,8 @@ transport:
 
 	result := NewClient(config)
 	require.Nil(t, result.Error, "Got %v", result.Error)
-	require.Equal(t, firstHop, result.Client.sd.FirstHop)
-	require.Equal(t, firstHop, result.Client.pl.FirstHop)
+	require.Equal(t, firstHop, result.Client.transportPair.StreamDialer.FirstHop)
+	require.Equal(t, firstHop, result.Client.transportPair.PacketProxy.FirstHop)
 }
 
 func Test_NewTransport_DisallowProxyless(t *testing.T) {
@@ -331,8 +331,8 @@ reporter:
 
 	result := NewClient(config)
 	require.Nil(t, result.Error, "Got %v", result.Error)
-	require.Equal(t, "example.com:80", result.Client.sd.FirstHop)
-	require.Equal(t, "example.com:53", result.Client.pl.FirstHop)
+	require.Equal(t, "example.com:80", result.Client.transportPair.StreamDialer.FirstHop)
+	require.Equal(t, "example.com:53", result.Client.transportPair.PacketProxy.FirstHop)
 	require.NotNil(t, result.Client.reporter, "Reporter is nil")
 	require.Equal(t, "https://your-callback-server.com/outline_callback", result.Client.reporter.(*reporting.HTTPReporter).URL.String())
 	require.Equal(t, 24*time.Hour, result.Client.reporter.(*reporting.HTTPReporter).Interval)

--- a/client/go/outline/config/config_tcpudp.go
+++ b/client/go/outline/config/config_tcpudp.go
@@ -31,13 +31,13 @@ type TCPUDPConfig struct {
 
 func NewTCPUDPTransportPairSubParser(
 	parseSD configyaml.ParseFunc[*Dialer[transport.StreamConn]],
-	parsePL configyaml.ParseFunc[*PacketListener]) func(ctx context.Context, input map[string]any) (*TransportPair, error) {
+	parsePPW configyaml.ParseFunc[*PacketProxyWrapper]) func(ctx context.Context, input map[string]any) (*TransportPair, error) {
 	return func(ctx context.Context, input map[string]any) (*TransportPair, error) {
-		return parseTCPUDPTransportPair(ctx, input, parseSD, parsePL)
+		return parseTCPUDPTransportPair(ctx, input, parseSD, parsePPW)
 	}
 }
 
-func parseTCPUDPTransportPair(ctx context.Context, configMap map[string]any, parseSD configyaml.ParseFunc[*Dialer[transport.StreamConn]], parsePL configyaml.ParseFunc[*PacketListener]) (*TransportPair, error) {
+func parseTCPUDPTransportPair(ctx context.Context, configMap map[string]any, parseSD configyaml.ParseFunc[*Dialer[transport.StreamConn]], parsePPW configyaml.ParseFunc[*PacketProxyWrapper]) (*TransportPair, error) {
 	var config TCPUDPConfig
 	if err := configyaml.MapToAny(configMap, &config); err != nil {
 		return nil, fmt.Errorf("invalid config format: %w", err)
@@ -48,13 +48,13 @@ func parseTCPUDPTransportPair(ctx context.Context, configMap map[string]any, par
 		return nil, fmt.Errorf("failed to parse StreamDialer: %w", err)
 	}
 
-	pl, err := parsePL(ctx, config.UDP)
+	ppw, err := parsePPW(ctx, config.UDP)
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse PacketListener: %w", err)
+		return nil, fmt.Errorf("failed to parse PacketProxyWrapper: %w", err)
 	}
 
 	return &TransportPair{
-		StreamDialer:   sd,
-		PacketListener: pl,
+		StreamDialer: sd,
+		PacketProxy:  ppw,
 	}, nil
 }

--- a/client/go/outline/config/module_test.go
+++ b/client/go/outline/config/module_test.go
@@ -47,11 +47,11 @@ udp: *shared`)
 	require.NoError(t, err)
 
 	require.NotNil(t, d.StreamDialer)
-	require.NotNil(t, d.PacketListener)
+	require.NotNil(t, d.PacketProxy)
 	require.Equal(t, "example.com:1234", d.StreamDialer.FirstHop)
 	require.Equal(t, ConnTypeTunneled, d.StreamDialer.ConnType)
-	require.Equal(t, "example.com:1234", d.PacketListener.FirstHop)
-	require.Equal(t, ConnTypeTunneled, d.PacketListener.ConnType)
+	require.Equal(t, "example.com:1234", d.PacketProxy.FirstHop)
+	require.Equal(t, ConnTypeTunneled, d.PacketProxy.ConnType)
 }
 
 func TestRegisterParseURL(t *testing.T) {
@@ -64,11 +64,11 @@ func TestRegisterParseURL(t *testing.T) {
 	require.NoError(t, err)
 
 	require.NotNil(t, d.StreamDialer)
-	require.NotNil(t, d.PacketListener)
+	require.NotNil(t, d.PacketProxy)
 	require.Equal(t, "example.com:4321", d.StreamDialer.FirstHop)
 	require.Equal(t, ConnTypeTunneled, d.StreamDialer.ConnType)
-	require.Equal(t, "example.com:4321", d.PacketListener.FirstHop)
-	require.Equal(t, ConnTypeTunneled, d.PacketListener.ConnType)
+	require.Equal(t, "example.com:4321", d.PacketProxy.FirstHop)
+	require.Equal(t, ConnTypeTunneled, d.PacketProxy.ConnType)
 }
 
 func TestRegisterParseURLInQuotes(t *testing.T) {
@@ -81,9 +81,9 @@ func TestRegisterParseURLInQuotes(t *testing.T) {
 	require.NoError(t, err)
 
 	require.NotNil(t, d.StreamDialer)
-	require.NotNil(t, d.PacketListener)
+	require.NotNil(t, d.PacketProxy)
 	require.Equal(t, "example.com:4321", d.StreamDialer.FirstHop)
 	require.Equal(t, ConnTypeTunneled, d.StreamDialer.ConnType)
-	require.Equal(t, "example.com:4321", d.PacketListener.FirstHop)
-	require.Equal(t, ConnTypeTunneled, d.PacketListener.ConnType)
+	require.Equal(t, "example.com:4321", d.PacketProxy.FirstHop)
+	require.Equal(t, ConnTypeTunneled, d.PacketProxy.ConnType)
 }

--- a/client/go/outline/config/packet_conn.go
+++ b/client/go/outline/config/packet_conn.go
@@ -1,0 +1,140 @@
+// Copyright 2024 The Outline Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"context"
+	"errors"
+	"net"
+	"net/netip"
+	"time"
+
+	"github.com/Jigsaw-Code/outline-sdk/network"
+)
+
+// packetConn is a net.PacketConn that sends and receives packets from a PacketProxy.
+type packetConn struct {
+	sender   network.PacketRequestSender
+	receiver *packetReceiver
+	readChan chan *packet
+	local    net.Addr
+	ctx      context.Context
+	cancel   context.CancelFunc
+}
+
+type packet struct {
+	data   []byte
+	source net.Addr
+}
+
+// packetReceiver implements network.PacketResponseReceiver to receive packets from the PacketProxy.
+type packetReceiver struct {
+	writeChan chan<- *packet
+	ctx       context.Context
+}
+
+func (r *packetReceiver) WriteFrom(p []byte, source net.Addr) (int, error) {
+	if r.ctx.Err() != nil {
+		return 0, r.ctx.Err()
+	}
+	// The buffer is owned by the caller, so we need to make a copy.
+	data := make([]byte, len(p))
+	copy(data, p)
+	select {
+	case r.writeChan <- &packet{data, source}:
+		return len(p), nil
+	case <-r.ctx.Done():
+		return 0, r.ctx.Err()
+	}
+}
+
+func (r *packetReceiver) Close() error {
+	// Closing the channel is handled by the packetConn.
+	return nil
+}
+
+func newPacketConn(ctx context.Context, proxy network.PacketProxy, localAddr net.Addr) (net.PacketConn, error) {
+	connCtx, connCancel := context.WithCancel(ctx)
+
+	readChan := make(chan *packet, 10)
+	receiver := &packetReceiver{readChan, connCtx}
+
+	sender, err := proxy.NewSession(receiver)
+	if err != nil {
+		connCancel()
+		close(readChan)
+		return nil, err
+	}
+
+	pc := &packetConn{
+		sender:   sender,
+		receiver: receiver,
+		readChan: readChan,
+		local:    localAddr,
+		ctx:      connCtx,
+		cancel:   connCancel,
+	}
+
+	go func() {
+		<-connCtx.Done()
+		pc.sender.Close()
+		close(pc.readChan)
+	}()
+
+	return pc, nil
+}
+
+func (c *packetConn) ReadFrom(p []byte) (n int, addr net.Addr, err error) {
+	select {
+	case pkt, ok := <-c.readChan:
+		if !ok {
+			return 0, nil, errors.New("connection closed")
+		}
+		n = copy(p, pkt.data)
+		return n, pkt.source, nil
+	case <-c.ctx.Done():
+		return 0, nil, c.ctx.Err()
+	}
+}
+
+func (c *packetConn) WriteTo(p []byte, addr net.Addr) (n int, err error) {
+	udpAddr, ok := addr.(*net.UDPAddr)
+	if !ok {
+		return 0, errors.New("address is not a UDP address")
+	}
+	ipPort := netip.AddrPortFrom(udpAddr.AddrPort().Addr(), udpAddr.AddrPort().Port())
+	return c.sender.WriteTo(p, ipPort)
+}
+
+func (c *packetConn) Close() error {
+	c.cancel()
+	return nil
+}
+
+func (c *packetConn) LocalAddr() net.Addr {
+	return c.local
+}
+
+func (c *packetConn) SetDeadline(t time.Time) error {
+	return &net.OpError{Op: "setdeadline", Net: "packet", Source: nil, Addr: nil, Err: errors.New("not supported")}
+}
+
+func (c *packetConn) SetReadDeadline(t time.Time) error {
+	return &net.OpError{Op: "setreaddeadline", Net: "packet", Source: nil, Addr: nil, Err: errors.New("not supported")}
+}
+
+func (c *packetConn) SetWriteDeadline(t time.Time) error {
+	return &net.OpError{Op: "setwritedeadline", Net: "packet", Source: nil, Addr: nil, Err: errors.New("not supported")}
+}

--- a/client/go/outline/parse.go
+++ b/client/go/outline/parse.go
@@ -133,8 +133,8 @@ func doParseTunnelConfig(input string) *InvokeMethodResult {
 		Client: string(clientConfigBytes),
 	}
 
-	streamFirstHop := result.Client.sd.ConnectionProviderInfo.FirstHop
-	packetFirstHop := result.Client.pl.ConnectionProviderInfo.FirstHop
+	streamFirstHop := result.Client.transportPair.StreamDialer.FirstHop
+	packetFirstHop := result.Client.transportPair.PacketProxy.FirstHop
 	if streamFirstHop == packetFirstHop {
 		response.FirstHop = streamFirstHop
 	}

--- a/client/go/outline/parse_test.go
+++ b/client/go/outline/parse_test.go
@@ -173,8 +173,8 @@ func TestParseConfig_SS_URL(t *testing.T) {
 	clientResult := NewClient(parsedOutput.Client)
 	require.Nil(t, clientResult.Error, "NewClient failed with parsed client config: %v", clientResult.Error)
 	require.NotNil(t, clientResult.Client)
-	require.Equal(t, expectedFirstHop, clientResult.Client.sd.FirstHop)
-	require.Equal(t, expectedFirstHop, clientResult.Client.pl.FirstHop)
+	require.Equal(t, expectedFirstHop, clientResult.Client.transportPair.StreamDialer.FirstHop)
+	require.Equal(t, expectedFirstHop, clientResult.Client.transportPair.PacketProxy.FirstHop)
 
 	matchTransportConfig(t, userInputConfig, result.Value)
 }
@@ -197,8 +197,8 @@ func TestParseConfig_Legacy_JSON(t *testing.T) {
 	clientResult := NewClient(parsedOutput.Client)
 	require.Nil(t, clientResult.Error, "NewClient failed with parsed client config: %v", clientResult.Error)
 	require.NotNil(t, clientResult.Client)
-	require.Equal(t, expectedFirstHop, clientResult.Client.sd.FirstHop)
-	require.Equal(t, expectedFirstHop, clientResult.Client.pl.FirstHop)
+	require.Equal(t, expectedFirstHop, clientResult.Client.transportPair.StreamDialer.FirstHop)
+	require.Equal(t, expectedFirstHop, clientResult.Client.transportPair.PacketProxy.FirstHop)
 
 	matchTransportConfig(t, userInputConfig, result.Value)
 }
@@ -222,8 +222,8 @@ func TestParseConfig_Legacy_JSON_WithPrefix(t *testing.T) {
 	clientResult := NewClient(parsedOutput.Client)
 	require.Nil(t, clientResult.Error, "NewClient failed with parsed client config: %v", clientResult.Error)
 	require.NotNil(t, clientResult.Client)
-	require.Equal(t, expectedFirstHop, clientResult.Client.sd.FirstHop)
-	require.Equal(t, expectedFirstHop, clientResult.Client.pl.FirstHop)
+	require.Equal(t, expectedFirstHop, clientResult.Client.transportPair.StreamDialer.FirstHop)
+	require.Equal(t, expectedFirstHop, clientResult.Client.transportPair.PacketProxy.FirstHop)
 
 	matchTransportConfig(t, userInputConfig, result.Value)
 }
@@ -242,8 +242,8 @@ func TestParseConfig_Legacy_JSONFlow_WithPrefix(t *testing.T) {
 	clientResult := NewClient(parsedOutput.Client)
 	require.Nil(t, clientResult.Error, "NewClient failed with parsed client config: %v", clientResult.Error)
 	require.NotNil(t, clientResult.Client)
-	require.Equal(t, expectedFirstHop, clientResult.Client.sd.FirstHop)
-	require.Equal(t, expectedFirstHop, clientResult.Client.pl.FirstHop)
+	require.Equal(t, expectedFirstHop, clientResult.Client.transportPair.StreamDialer.FirstHop)
+	require.Equal(t, expectedFirstHop, clientResult.Client.transportPair.PacketProxy.FirstHop)
 
 	matchTransportConfig(t, userInputConfig, result.Value)
 }
@@ -267,8 +267,8 @@ func TestParseConfig_Transport_JSON_WithPrefix(t *testing.T) {
 	clientResult := NewClient(parsedOutput.Client)
 	require.Nil(t, clientResult.Error, "NewClient failed with parsed client config: %v", clientResult.Error)
 	require.NotNil(t, clientResult.Client)
-	require.Equal(t, expectedFirstHop, clientResult.Client.sd.FirstHop)
-	require.Equal(t, expectedFirstHop, clientResult.Client.pl.FirstHop)
+	require.Equal(t, expectedFirstHop, clientResult.Client.transportPair.StreamDialer.FirstHop)
+	require.Equal(t, expectedFirstHop, clientResult.Client.transportPair.PacketProxy.FirstHop)
 
 	matchClientConfig(t, userInputConfig, result.Value)
 }
@@ -316,8 +316,8 @@ func TestParseConfig_Flexible_JSON(t *testing.T) {
 	clientResult := NewClient(parsedOutput.Client)
 	require.Nil(t, clientResult.Error, "NewClient failed with parsed client config: %v", clientResult.Error)
 	require.NotNil(t, clientResult.Client)
-	require.Equal(t, expectedFirstHop, clientResult.Client.sd.FirstHop)
-	require.Equal(t, expectedFirstHop, clientResult.Client.pl.FirstHop)
+	require.Equal(t, expectedFirstHop, clientResult.Client.transportPair.StreamDialer.FirstHop)
+	require.Equal(t, expectedFirstHop, clientResult.Client.transportPair.PacketProxy.FirstHop)
 
 	matchTransportConfig(t, userInputConfig, result.Value)
 }
@@ -342,8 +342,8 @@ prefix: "SSH-2.0\r\n"`
 	clientResult := NewClient(parsedOutput.Client)
 	require.Nil(t, clientResult.Error, "NewClient failed with parsed client config: %v", clientResult.Error)
 	require.NotNil(t, clientResult.Client)
-	require.Equal(t, expectedFirstHop, clientResult.Client.sd.FirstHop)
-	require.Equal(t, expectedFirstHop, clientResult.Client.pl.FirstHop)
+	require.Equal(t, expectedFirstHop, clientResult.Client.transportPair.StreamDialer.FirstHop)
+	require.Equal(t, expectedFirstHop, clientResult.Client.transportPair.PacketProxy.FirstHop)
 
 	matchTransportConfig(t, userInputConfig, result.Value)
 }
@@ -367,8 +367,8 @@ prefix: "SSH-2.0\r\n"`
 	clientResult := NewClient(parsedOutput.Client)
 	require.Nil(t, clientResult.Error, "NewClient failed with parsed client config: %v", clientResult.Error)
 	require.NotNil(t, clientResult.Client)
-	require.Equal(t, expectedFirstHop, clientResult.Client.sd.FirstHop)
-	require.Equal(t, expectedFirstHop, clientResult.Client.pl.FirstHop)
+	require.Equal(t, expectedFirstHop, clientResult.Client.transportPair.StreamDialer.FirstHop)
+	require.Equal(t, expectedFirstHop, clientResult.Client.transportPair.PacketProxy.FirstHop)
 
 	matchTransportConfig(t, userInputConfig, result.Value)
 }
@@ -393,8 +393,8 @@ prefix: "SSH-2.0\r\n"`
 	clientResult := NewClient(parsedOutput.Client)
 	require.Nil(t, clientResult.Error, "NewClient failed with parsed client config: %v", clientResult.Error)
 	require.NotNil(t, clientResult.Client)
-	require.Equal(t, expectedFirstHop, clientResult.Client.sd.FirstHop)
-	require.Equal(t, expectedFirstHop, clientResult.Client.pl.FirstHop)
+	require.Equal(t, expectedFirstHop, clientResult.Client.transportPair.StreamDialer.FirstHop)
+	require.Equal(t, expectedFirstHop, clientResult.Client.transportPair.PacketProxy.FirstHop)
 
 	matchTransportConfig(t, userInputConfig, result.Value)
 }
@@ -423,8 +423,8 @@ prefix: "SSH-2.0\r\n"`
 	clientResult := NewClient(parsedOutput.Client)
 	require.Nil(t, clientResult.Error, "NewClient failed with parsed client config: %v", clientResult.Error)
 	require.NotNil(t, clientResult.Client)
-	require.Equal(t, expectedFirstHop, clientResult.Client.sd.FirstHop)
-	require.Equal(t, expectedFirstHop, clientResult.Client.pl.FirstHop)
+	require.Equal(t, expectedFirstHop, clientResult.Client.transportPair.StreamDialer.FirstHop)
+	require.Equal(t, expectedFirstHop, clientResult.Client.transportPair.PacketProxy.FirstHop)
 
 	matchTransportConfig(t, userInputConfig, result.Value)
 }
@@ -457,8 +457,8 @@ udp:
 	clientResult := NewClient(parsedOutput.Client)
 	require.Nil(t, clientResult.Error, "NewClient failed with parsed client config: %v", clientResult.Error)
 	require.NotNil(t, clientResult.Client)
-	require.Equal(t, expectedSdFirstHop, clientResult.Client.sd.FirstHop)
-	require.Equal(t, expectedPlFirstHop, clientResult.Client.pl.FirstHop)
+	require.Equal(t, expectedSdFirstHop, clientResult.Client.transportPair.StreamDialer.FirstHop)
+	require.Equal(t, expectedPlFirstHop, clientResult.Client.transportPair.PacketProxy.FirstHop)
 
 	matchTransportConfig(t, userInputConfig, result.Value)
 }

--- a/client/go/outline/vpn/vpn.go
+++ b/client/go/outline/vpn/vpn.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/Jigsaw-Code/outline-apps/client/go/outline/callback"
+	"github.com/Jigsaw-Code/outline-apps/client/go/outline/config"
 	"github.com/Jigsaw-Code/outline-sdk/transport"
 )
 
@@ -104,7 +105,7 @@ func SetStateChangeListener(token callback.Token) {
 // newly created [VPNConnection] as the currently active connection.
 // It returns the new [VPNConnection], or an error if the connection fails.
 func EstablishVPN(
-	ctx context.Context, conf *Config, sd transport.StreamDialer, pl transport.PacketListener,
+	ctx context.Context, conf *Config, sd transport.StreamDialer, proxy *config.PacketProxyWrapper,
 ) (_ *VPNConnection, err error) {
 	if conf == nil {
 		panic("a VPN config must be provided")
@@ -112,8 +113,8 @@ func EstablishVPN(
 	if sd == nil {
 		panic("a StreamDialer must be provided")
 	}
-	if pl == nil {
-		panic("a PacketListener must be provided")
+	if proxy == nil {
+		panic("a PacketProxy must be provided")
 	}
 
 	c := &VPNConnection{ID: conf.ID, Status: ConnectionDisconnected}
@@ -141,7 +142,7 @@ func EstablishVPN(
 		}
 	}()
 
-	if c.proxy, err = ConnectRemoteDevice(ctx, sd, pl); err != nil {
+	if c.proxy, err = ConnectRemoteDevice(ctx, sd, proxy); err != nil {
 		slog.Error("failed to connect to the remote device", "err", err)
 		return
 	}

--- a/client/go/outline/vpn_linux.go
+++ b/client/go/outline/vpn_linux.go
@@ -80,7 +80,7 @@ func (api *vpnAPI) Establish(configStr string) (err error) {
 			}
 		}
 	}()
-	_, err = vpn.EstablishVPN(context.Background(), &conf.VPN, client, client)
+	_, err = vpn.EstablishVPN(context.Background(), &conf.VPN, client, client.PacketProxy())
 
 	api.clientMu.Lock()
 	if api.client != nil {


### PR DESCRIPTION
experimenting with jules

This change replaces the `PacketListener` struct with a `PacketProxyWrapper` struct that embeds a `network.PacketProxy` and `ConnectionProviderInfo`. This allows the application to use the more flexible `PacketProxy` interface for handling UDP traffic.

The `packetConn` implementation has been moved to its own file `packet_conn.go` for better code organization.

The patch also includes:
- An adapter to make `PacketProxy` compatible with `net.PacketConn` where needed.
- Updates to all parts of the codebase that were dependent on `PacketListener` to use the new `PacketProxyWrapper`.
- Refactoring of `vpn.go` to have a cleaner API.
- Fixes to all related tests.