### PR TITLE
fix(client): import missing messages for connect/disconnect

### DIFF
--- a/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/af.lproj/Localizable.strings
+++ b/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/af.lproj/Localizable.strings
@@ -1,4 +1,4 @@
 "tray_open_window" = "Oop";
 "quit" = "Verlaat";
-"disconnect" = "Disconnect";
-"connect" = "Connect";
+"disconnect_button_label" = "Ontkoppel";
+"connect_button_label" = "Koppel";

--- a/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/af.lproj/Localizable.strings
+++ b/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/af.lproj/Localizable.strings
@@ -1,4 +1,4 @@
-"connected_server_state" = "Gekoppel";
-"disconnected_server_state" = "Ontkoppel";
 "tray_open_window" = "Oop";
 "quit" = "Verlaat";
+"disconnect" = "Disconnect";
+"connect" = "Connect";

--- a/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/am.lproj/Localizable.strings
+++ b/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/am.lproj/Localizable.strings
@@ -1,4 +1,4 @@
 "tray_open_window" = "ክፈት";
 "quit" = "ጨርስ";
-"disconnect" = "Disconnect";
-"connect" = "Connect";
+"disconnect_button_label" = "የእርስዎ ግብረመልስ";
+"connect_button_label" = "አገናኝ";

--- a/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/am.lproj/Localizable.strings
+++ b/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/am.lproj/Localizable.strings
@@ -1,4 +1,4 @@
-"connected_server_state" = "ተገናኝቷል";
-"disconnected_server_state" = "ተቋርጧል";
 "tray_open_window" = "ክፈት";
 "quit" = "ጨርስ";
+"disconnect" = "Disconnect";
+"connect" = "Connect";

--- a/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/ar.lproj/Localizable.strings
+++ b/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/ar.lproj/Localizable.strings
@@ -1,4 +1,4 @@
 "tray_open_window" = "فتح";
 "quit" = "إنهاء";
-"disconnect" = "Disconnect";
-"connect" = "Connect";
+"disconnect_button_label" = "قطع الاتصال";
+"connect_button_label" = "اتصال";

--- a/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/ar.lproj/Localizable.strings
+++ b/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/ar.lproj/Localizable.strings
@@ -1,4 +1,4 @@
-"connected_server_state" = "متصل";
-"disconnected_server_state" = "غير متصل";
 "tray_open_window" = "فتح";
 "quit" = "إنهاء";
+"disconnect" = "Disconnect";
+"connect" = "Connect";

--- a/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/az.lproj/Localizable.strings
+++ b/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/az.lproj/Localizable.strings
@@ -1,4 +1,4 @@
-"connected_server_state" = "Qoşuldu";
-"disconnected_server_state" = "Bağlantı kəsildi";
 "tray_open_window" = "Açın";
 "quit" = "Çıxın";
+"disconnect" = "Disconnect";
+"connect" = "Connect";

--- a/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/az.lproj/Localizable.strings
+++ b/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/az.lproj/Localizable.strings
@@ -1,4 +1,4 @@
 "tray_open_window" = "Açın";
 "quit" = "Çıxın";
-"disconnect" = "Disconnect";
-"connect" = "Connect";
+"disconnect_button_label" = "Bağlantını kəsin";
+"connect_button_label" = "Qoşulun";

--- a/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/bg.lproj/Localizable.strings
+++ b/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/bg.lproj/Localizable.strings
@@ -1,4 +1,4 @@
 "tray_open_window" = "Отваряне";
 "quit" = "Излизане";
-"disconnect" = "Disconnect";
-"connect" = "Connect";
+"disconnect_button_label" = "Прекратяване на връзката";
+"connect_button_label" = "Свързване";

--- a/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/bg.lproj/Localizable.strings
+++ b/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/bg.lproj/Localizable.strings
@@ -1,4 +1,4 @@
-"connected_server_state" = "Установена е връзка";
-"disconnected_server_state" = "Връзката бе прекратена";
 "tray_open_window" = "Отваряне";
 "quit" = "Излизане";
+"disconnect" = "Disconnect";
+"connect" = "Connect";

--- a/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/bn.lproj/Localizable.strings
+++ b/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/bn.lproj/Localizable.strings
@@ -1,4 +1,4 @@
-"connected_server_state" = "কানেক্ট করা আছে";
-"disconnected_server_state" = "ডিসকানেক্ট হয়ে গেছে";
 "tray_open_window" = "খুলুন";
 "quit" = "বেরিয়ে আসুন";
+"disconnect" = "Disconnect";
+"connect" = "Connect";

--- a/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/bn.lproj/Localizable.strings
+++ b/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/bn.lproj/Localizable.strings
@@ -1,4 +1,4 @@
 "tray_open_window" = "খুলুন";
 "quit" = "বেরিয়ে আসুন";
-"disconnect" = "Disconnect";
-"connect" = "Connect";
+"disconnect_button_label" = "ডিসকানেক্ট করুন";
+"connect_button_label" = "কানেক্ট করুন";

--- a/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/bs.lproj/Localizable.strings
+++ b/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/bs.lproj/Localizable.strings
@@ -1,4 +1,4 @@
-"connected_server_state" = "Povezano";
-"disconnected_server_state" = "Veza je prekinuta";
 "tray_open_window" = "Otvori";
 "quit" = "Napusti";
+"disconnect" = "Disconnect";
+"connect" = "Connect";

--- a/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/bs.lproj/Localizable.strings
+++ b/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/bs.lproj/Localizable.strings
@@ -1,4 +1,4 @@
 "tray_open_window" = "Otvori";
 "quit" = "Napusti";
-"disconnect" = "Disconnect";
-"connect" = "Connect";
+"disconnect_button_label" = "Prekini vezu";
+"connect_button_label" = "Poveži";

--- a/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/ca.lproj/Localizable.strings
+++ b/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/ca.lproj/Localizable.strings
@@ -1,4 +1,4 @@
 "tray_open_window" = "Obre";
 "quit" = "Surt";
-"disconnect" = "Disconnect";
-"connect" = "Connect";
+"disconnect_button_label" = "Desconnecta";
+"connect_button_label" = "Connecta";

--- a/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/ca.lproj/Localizable.strings
+++ b/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/ca.lproj/Localizable.strings
@@ -1,4 +1,4 @@
-"connected_server_state" = "Connectat";
-"disconnected_server_state" = "Desconnectat";
 "tray_open_window" = "Obre";
 "quit" = "Surt";
+"disconnect" = "Disconnect";
+"connect" = "Connect";

--- a/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/cs.lproj/Localizable.strings
+++ b/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/cs.lproj/Localizable.strings
@@ -1,4 +1,4 @@
-"connected_server_state" = "Připojeno";
-"disconnected_server_state" = "Odpojeno";
 "tray_open_window" = "Otevřít";
 "quit" = "Zavřít";
+"disconnect" = "Disconnect";
+"connect" = "Connect";

--- a/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/cs.lproj/Localizable.strings
+++ b/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/cs.lproj/Localizable.strings
@@ -1,4 +1,4 @@
 "tray_open_window" = "Otevřít";
 "quit" = "Zavřít";
-"disconnect" = "Disconnect";
-"connect" = "Connect";
+"disconnect_button_label" = "Odpojit";
+"connect_button_label" = "Připojit";

--- a/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/da.lproj/Localizable.strings
+++ b/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/da.lproj/Localizable.strings
@@ -1,4 +1,4 @@
-"connected_server_state" = "Forbundet";
-"disconnected_server_state" = "Forbindelsen er afbrudt";
 "tray_open_window" = "Åbn";
 "quit" = "Luk";
+"disconnect" = "Disconnect";
+"connect" = "Connect";

--- a/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/da.lproj/Localizable.strings
+++ b/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/da.lproj/Localizable.strings
@@ -1,4 +1,4 @@
 "tray_open_window" = "Åbn";
 "quit" = "Luk";
-"disconnect" = "Disconnect";
-"connect" = "Connect";
+"disconnect_button_label" = "Afbryd forbindelsen";
+"connect_button_label" = "Opret forbindelse";

--- a/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/de.lproj/Localizable.strings
+++ b/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/de.lproj/Localizable.strings
@@ -1,4 +1,4 @@
-"connected_server_state" = "Verbunden";
-"disconnected_server_state" = "Nicht verbunden";
 "tray_open_window" = "Öffnen";
 "quit" = "Beenden";
+"disconnect" = "Disconnect";
+"connect" = "Connect";

--- a/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/de.lproj/Localizable.strings
+++ b/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/de.lproj/Localizable.strings
@@ -1,4 +1,4 @@
 "tray_open_window" = "Öffnen";
 "quit" = "Beenden";
-"disconnect" = "Disconnect";
-"connect" = "Connect";
+"disconnect_button_label" = "Verbindung trennen";
+"connect_button_label" = "Verbinden";

--- a/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/el.lproj/Localizable.strings
+++ b/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/el.lproj/Localizable.strings
@@ -1,4 +1,4 @@
-"connected_server_state" = "Συνδεδεμένος";
-"disconnected_server_state" = "Αποσυνδεδεμένος";
 "tray_open_window" = "Άνοιγμα";
 "quit" = "Έξοδος";
+"disconnect" = "Disconnect";
+"connect" = "Connect";

--- a/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/el.lproj/Localizable.strings
+++ b/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/el.lproj/Localizable.strings
@@ -1,4 +1,4 @@
 "tray_open_window" = "Άνοιγμα";
 "quit" = "Έξοδος";
-"disconnect" = "Disconnect";
-"connect" = "Connect";
+"disconnect_button_label" = "Αποσύνδεση";
+"connect_button_label" = "Σύνδεση";

--- a/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/en-GB.lproj/Localizable.strings
+++ b/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/en-GB.lproj/Localizable.strings
@@ -1,4 +1,4 @@
-"connected_server_state" = "Connected";
-"disconnected_server_state" = "Disconnected";
 "tray_open_window" = "Open";
 "quit" = "Exit";
+"disconnect" = "Disconnect";
+"connect" = "Connect";

--- a/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/en-GB.lproj/Localizable.strings
+++ b/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/en-GB.lproj/Localizable.strings
@@ -1,4 +1,4 @@
 "tray_open_window" = "Open";
 "quit" = "Exit";
-"disconnect" = "Disconnect";
-"connect" = "Connect";
+"disconnect_button_label" = "Disconnect";
+"connect_button_label" = "Connect";

--- a/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/en.lproj/Localizable.strings
+++ b/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/en.lproj/Localizable.strings
@@ -1,4 +1,4 @@
 "tray_open_window" = "Open";
 "quit" = "Quit";
-"disconnect" = "Disconnect";
-"connect" = "Connect";
+"disconnect_button_label" = "Disconnect";
+"connect_button_label" = "Connect";

--- a/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/es-419.lproj/Localizable.strings
+++ b/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/es-419.lproj/Localizable.strings
@@ -1,4 +1,4 @@
-"connected_server_state" = "Conectado";
-"disconnected_server_state" = "Desconectado";
 "tray_open_window" = "Abrir";
 "quit" = "Salir";
+"disconnect" = "Disconnect";
+"connect" = "Connect";

--- a/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/es-419.lproj/Localizable.strings
+++ b/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/es-419.lproj/Localizable.strings
@@ -1,4 +1,4 @@
 "tray_open_window" = "Abrir";
 "quit" = "Salir";
-"disconnect" = "Disconnect";
-"connect" = "Connect";
+"disconnect_button_label" = "Desconectar";
+"connect_button_label" = "Conectar";

--- a/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/es.lproj/Localizable.strings
+++ b/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/es.lproj/Localizable.strings
@@ -1,4 +1,4 @@
-"connected_server_state" = "Conectado";
-"disconnected_server_state" = "Desconectado";
 "tray_open_window" = "Abrir";
 "quit" = "Cerrar";
+"disconnect" = "Disconnect";
+"connect" = "Connect";

--- a/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/es.lproj/Localizable.strings
+++ b/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/es.lproj/Localizable.strings
@@ -1,4 +1,4 @@
 "tray_open_window" = "Abrir";
 "quit" = "Cerrar";
-"disconnect" = "Disconnect";
-"connect" = "Connect";
+"disconnect_button_label" = "Desconectar";
+"connect_button_label" = "Conectar";

--- a/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/et.lproj/Localizable.strings
+++ b/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/et.lproj/Localizable.strings
@@ -1,4 +1,4 @@
 "tray_open_window" = "Ava";
 "quit" = "Välju";
-"disconnect" = "Disconnect";
-"connect" = "Connect";
+"disconnect_button_label" = "Katkesta ühendus";
+"connect_button_label" = "Ühenda";

--- a/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/et.lproj/Localizable.strings
+++ b/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/et.lproj/Localizable.strings
@@ -1,4 +1,4 @@
-"connected_server_state" = "Ühendatud";
-"disconnected_server_state" = "Ühendus on katkestatud";
 "tray_open_window" = "Ava";
 "quit" = "Välju";
+"disconnect" = "Disconnect";
+"connect" = "Connect";

--- a/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/fa.lproj/Localizable.strings
+++ b/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/fa.lproj/Localizable.strings
@@ -1,4 +1,4 @@
 "tray_open_window" = "باز کردن";
 "quit" = "خروج";
-"disconnect" = "Disconnect";
-"connect" = "Connect";
+"disconnect_button_label" = "قطع اتصال";
+"connect_button_label" = "متصل کردن";

--- a/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/fa.lproj/Localizable.strings
+++ b/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/fa.lproj/Localizable.strings
@@ -1,4 +1,4 @@
-"connected_server_state" = "وصل شدید";
-"disconnected_server_state" = "اتصال قطع شد";
 "tray_open_window" = "باز کردن";
 "quit" = "خروج";
+"disconnect" = "Disconnect";
+"connect" = "Connect";

--- a/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/fi.lproj/Localizable.strings
+++ b/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/fi.lproj/Localizable.strings
@@ -1,4 +1,4 @@
 "tray_open_window" = "Avaa";
 "quit" = "Sulje";
-"disconnect" = "Disconnect";
-"connect" = "Connect";
+"disconnect_button_label" = "Katkaise yhteys";
+"connect_button_label" = "Yhdistä";

--- a/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/fi.lproj/Localizable.strings
+++ b/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/fi.lproj/Localizable.strings
@@ -1,4 +1,4 @@
-"connected_server_state" = "Yhdistetty";
-"disconnected_server_state" = "Yhteys katkaistu";
 "tray_open_window" = "Avaa";
 "quit" = "Sulje";
+"disconnect" = "Disconnect";
+"connect" = "Connect";

--- a/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/fil.lproj/Localizable.strings
+++ b/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/fil.lproj/Localizable.strings
@@ -1,4 +1,4 @@
 "tray_open_window" = "Buksan";
 "quit" = "Umalis";
-"disconnect" = "Disconnect";
-"connect" = "Connect";
+"disconnect_button_label" = "Idiskonekta";
+"connect_button_label" = "Ikonekta";

--- a/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/fil.lproj/Localizable.strings
+++ b/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/fil.lproj/Localizable.strings
@@ -1,4 +1,4 @@
-"connected_server_state" = "Nakakonekta na";
-"disconnected_server_state" = "Nadiskonekta";
 "tray_open_window" = "Buksan";
 "quit" = "Umalis";
+"disconnect" = "Disconnect";
+"connect" = "Connect";

--- a/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/fr.lproj/Localizable.strings
+++ b/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/fr.lproj/Localizable.strings
@@ -1,4 +1,4 @@
 "tray_open_window" = "Ouvrir";
 "quit" = "Quitter";
-"disconnect" = "Disconnect";
-"connect" = "Connect";
+"disconnect_button_label" = "Déconnecter";
+"connect_button_label" = "Connecter";

--- a/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/fr.lproj/Localizable.strings
+++ b/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/fr.lproj/Localizable.strings
@@ -1,4 +1,4 @@
-"connected_server_state" = "Connecté";
-"disconnected_server_state" = "Déconnecté";
 "tray_open_window" = "Ouvrir";
 "quit" = "Quitter";
+"disconnect" = "Disconnect";
+"connect" = "Connect";

--- a/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/he.lproj/Localizable.strings
+++ b/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/he.lproj/Localizable.strings
@@ -1,4 +1,4 @@
-"connected_server_state" = "מחובר";
-"disconnected_server_state" = "מנותק";
 "tray_open_window" = "פתיחה";
 "quit" = "יציאה";
+"disconnect" = "Disconnect";
+"connect" = "Connect";

--- a/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/he.lproj/Localizable.strings
+++ b/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/he.lproj/Localizable.strings
@@ -1,4 +1,4 @@
 "tray_open_window" = "פתיחה";
 "quit" = "יציאה";
-"disconnect" = "Disconnect";
-"connect" = "Connect";
+"disconnect_button_label" = "ניתוק";
+"connect_button_label" = "חיבור";

--- a/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/hi.lproj/Localizable.strings
+++ b/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/hi.lproj/Localizable.strings
@@ -1,4 +1,4 @@
-"connected_server_state" = "कनेक्ट किया गया";
-"disconnected_server_state" = "डिसकनेक्ट किया गया";
 "tray_open_window" = "खोलें";
 "quit" = "छोड़ें";
+"disconnect" = "Disconnect";
+"connect" = "Connect";

--- a/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/hi.lproj/Localizable.strings
+++ b/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/hi.lproj/Localizable.strings
@@ -1,4 +1,4 @@
 "tray_open_window" = "खोलें";
 "quit" = "छोड़ें";
-"disconnect" = "Disconnect";
-"connect" = "Connect";
+"disconnect_button_label" = "डिसकनेक्ट करें";
+"connect_button_label" = "कनेक्ट करें";

--- a/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/hr.lproj/Localizable.strings
+++ b/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/hr.lproj/Localizable.strings
@@ -1,4 +1,4 @@
 "tray_open_window" = "Otvori";
 "quit" = "Zatvori";
-"disconnect" = "Disconnect";
-"connect" = "Connect";
+"disconnect_button_label" = "Prekini vezu";
+"connect_button_label" = "Poveži";

--- a/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/hr.lproj/Localizable.strings
+++ b/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/hr.lproj/Localizable.strings
@@ -1,4 +1,4 @@
-"connected_server_state" = "Povezano";
-"disconnected_server_state" = "Veza je prekinuta";
 "tray_open_window" = "Otvori";
 "quit" = "Zatvori";
+"disconnect" = "Disconnect";
+"connect" = "Connect";

--- a/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/hu.lproj/Localizable.strings
+++ b/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/hu.lproj/Localizable.strings
@@ -1,4 +1,4 @@
-"connected_server_state" = "Csatlakoztatva";
-"disconnected_server_state" = "Leválasztva";
 "tray_open_window" = "Megnyitás";
 "quit" = "Kilépés";
+"disconnect" = "Disconnect";
+"connect" = "Connect";

--- a/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/hu.lproj/Localizable.strings
+++ b/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/hu.lproj/Localizable.strings
@@ -1,4 +1,4 @@
 "tray_open_window" = "Megnyitás";
 "quit" = "Kilépés";
-"disconnect" = "Disconnect";
-"connect" = "Connect";
+"disconnect_button_label" = "Leválasztás";
+"connect_button_label" = "Csatlakozás";

--- a/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/hy.lproj/Localizable.strings
+++ b/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/hy.lproj/Localizable.strings
@@ -1,4 +1,4 @@
-"connected_server_state" = "Միացված է";
-"disconnected_server_state" = "Անջատված է";
 "tray_open_window" = "Բացել";
 "quit" = "Փակել";
+"disconnect" = "Disconnect";
+"connect" = "Connect";

--- a/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/hy.lproj/Localizable.strings
+++ b/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/hy.lproj/Localizable.strings
@@ -1,4 +1,4 @@
 "tray_open_window" = "Բացել";
 "quit" = "Փակել";
-"disconnect" = "Disconnect";
-"connect" = "Connect";
+"disconnect_button_label" = "Անջատել";
+"connect_button_label" = "Միանալ";

--- a/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/id.lproj/Localizable.strings
+++ b/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/id.lproj/Localizable.strings
@@ -1,4 +1,4 @@
-"connected_server_state" = "Terhubung";
-"disconnected_server_state" = "Tidak terhubung";
 "tray_open_window" = "Buka";
 "quit" = "Tutup";
+"disconnect" = "Disconnect";
+"connect" = "Connect";

--- a/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/id.lproj/Localizable.strings
+++ b/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/id.lproj/Localizable.strings
@@ -1,4 +1,4 @@
 "tray_open_window" = "Buka";
 "quit" = "Tutup";
-"disconnect" = "Disconnect";
-"connect" = "Connect";
+"disconnect_button_label" = "Berhenti hubungkan";
+"connect_button_label" = "Sambungkan";

--- a/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/is.lproj/Localizable.strings
+++ b/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/is.lproj/Localizable.strings
@@ -1,4 +1,4 @@
-"connected_server_state" = "Tengt";
-"disconnected_server_state" = "Aftengt";
 "tray_open_window" = "Opna";
 "quit" = "Hætta";
+"disconnect" = "Disconnect";
+"connect" = "Connect";

--- a/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/is.lproj/Localizable.strings
+++ b/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/is.lproj/Localizable.strings
@@ -1,4 +1,4 @@
 "tray_open_window" = "Opna";
 "quit" = "Hætta";
-"disconnect" = "Disconnect";
-"connect" = "Connect";
+"disconnect_button_label" = "Aftengja";
+"connect_button_label" = "Tengja";

--- a/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/it.lproj/Localizable.strings
+++ b/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/it.lproj/Localizable.strings
@@ -1,4 +1,4 @@
-"connected_server_state" = "Connesso";
-"disconnected_server_state" = "Server disconnesso";
 "tray_open_window" = "Apri";
 "quit" = "Esci";
+"disconnect" = "Disconnect";
+"connect" = "Connect";

--- a/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/it.lproj/Localizable.strings
+++ b/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/it.lproj/Localizable.strings
@@ -1,4 +1,4 @@
 "tray_open_window" = "Apri";
 "quit" = "Esci";
-"disconnect" = "Disconnect";
-"connect" = "Connect";
+"disconnect_button_label" = "Disconnetti";
+"connect_button_label" = "Connetti";

--- a/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/ja.lproj/Localizable.strings
+++ b/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/ja.lproj/Localizable.strings
@@ -1,4 +1,4 @@
 "tray_open_window" = "開く";
 "quit" = "終了";
-"disconnect" = "Disconnect";
-"connect" = "Connect";
+"disconnect_button_label" = "接続を切断";
+"connect_button_label" = "接続";

--- a/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/ja.lproj/Localizable.strings
+++ b/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/ja.lproj/Localizable.strings
@@ -1,4 +1,4 @@
-"connected_server_state" = "接続しました";
-"disconnected_server_state" = "接続が切断されました";
 "tray_open_window" = "開く";
 "quit" = "終了";
+"disconnect" = "Disconnect";
+"connect" = "Connect";

--- a/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/ka.lproj/Localizable.strings
+++ b/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/ka.lproj/Localizable.strings
@@ -1,4 +1,4 @@
 "tray_open_window" = "ღიაა";
 "quit" = "გასვლა";
-"disconnect" = "Disconnect";
-"connect" = "Connect";
+"disconnect_button_label" = "კავშირის გაწყვეტა";
+"connect_button_label" = "დაკავშირება";

--- a/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/ka.lproj/Localizable.strings
+++ b/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/ka.lproj/Localizable.strings
@@ -1,4 +1,4 @@
-"connected_server_state" = "დაკავშირებულია";
-"disconnected_server_state" = "კავშირი გაწყვეტილია";
 "tray_open_window" = "ღიაა";
 "quit" = "გასვლა";
+"disconnect" = "Disconnect";
+"connect" = "Connect";

--- a/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/kk.lproj/Localizable.strings
+++ b/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/kk.lproj/Localizable.strings
@@ -1,4 +1,4 @@
-"connected_server_state" = "Байланыс орнатылды.";
-"disconnected_server_state" = "Ажыратылған";
 "tray_open_window" = "Ашу";
 "quit" = "Шығу";
+"disconnect" = "Disconnect";
+"connect" = "Connect";

--- a/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/kk.lproj/Localizable.strings
+++ b/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/kk.lproj/Localizable.strings
@@ -1,4 +1,4 @@
 "tray_open_window" = "Ашу";
 "quit" = "Шығу";
-"disconnect" = "Disconnect";
-"connect" = "Connect";
+"disconnect_button_label" = "Ажырату";
+"connect_button_label" = "Жалғау";

--- a/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/km.lproj/Localizable.strings
+++ b/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/km.lproj/Localizable.strings
@@ -1,4 +1,4 @@
 "tray_open_window" = "បើក";
 "quit" = "ចាកចេញ";
-"disconnect" = "Disconnect";
-"connect" = "Connect";
+"disconnect_button_label" = "ផ្តាច់";
+"connect_button_label" = "ភ្ជាប់";

--- a/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/km.lproj/Localizable.strings
+++ b/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/km.lproj/Localizable.strings
@@ -1,4 +1,4 @@
-"connected_server_state" = "បានភ្ជាប់";
-"disconnected_server_state" = "បានផ្ដាច់";
 "tray_open_window" = "បើក";
 "quit" = "ចាកចេញ";
+"disconnect" = "Disconnect";
+"connect" = "Connect";

--- a/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/ko.lproj/Localizable.strings
+++ b/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/ko.lproj/Localizable.strings
@@ -1,6 +1,4 @@
-"connected_server_state" = "연결됨";
-"disconnected_server_state" = "연결 해제됨";
 "tray_open_window" = "열기";
 "quit" = "종료";
-"disconnect" = "연결 해제";
-"connect" = "연결";
+"disconnect" = "Disconnect";
+"connect" = "Connect";

--- a/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/ko.lproj/Localizable.strings
+++ b/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/ko.lproj/Localizable.strings
@@ -1,4 +1,4 @@
 "tray_open_window" = "열기";
 "quit" = "종료";
-"disconnect" = "Disconnect";
-"connect" = "Connect";
+"disconnect_button_label" = "연결 해제";
+"connect_button_label" = "연결";

--- a/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/lo.lproj/Localizable.strings
+++ b/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/lo.lproj/Localizable.strings
@@ -1,4 +1,4 @@
 "tray_open_window" = "ເປີດ";
 "quit" = "ປິດ";
-"disconnect" = "Disconnect";
-"connect" = "Connect";
+"disconnect_button_label" = "ຕັດການເຊື່ອມຕໍ່";
+"connect_button_label" = "ເຊື່ອມຕໍ່";

--- a/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/lo.lproj/Localizable.strings
+++ b/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/lo.lproj/Localizable.strings
@@ -1,4 +1,4 @@
-"connected_server_state" = "ເຊື່ອມຕໍ່ແລ້ວ";
-"disconnected_server_state" = "ຕັດການເຊື່ອມຕໍ່ແລ້ວ";
 "tray_open_window" = "ເປີດ";
 "quit" = "ປິດ";
+"disconnect" = "Disconnect";
+"connect" = "Connect";

--- a/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/lt.lproj/Localizable.strings
+++ b/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/lt.lproj/Localizable.strings
@@ -1,4 +1,4 @@
-"connected_server_state" = "Prisijungta";
-"disconnected_server_state" = "Atsijungta";
 "tray_open_window" = "Atidaryti";
 "quit" = "Išeiti";
+"disconnect" = "Disconnect";
+"connect" = "Connect";

--- a/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/lt.lproj/Localizable.strings
+++ b/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/lt.lproj/Localizable.strings
@@ -1,4 +1,4 @@
 "tray_open_window" = "Atidaryti";
 "quit" = "Išeiti";
-"disconnect" = "Disconnect";
-"connect" = "Connect";
+"disconnect_button_label" = "Atsijungti";
+"connect_button_label" = "Prisijungti";

--- a/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/lv.lproj/Localizable.strings
+++ b/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/lv.lproj/Localizable.strings
@@ -1,4 +1,4 @@
 "tray_open_window" = "Atvērt";
 "quit" = "Aizvērt";
-"disconnect" = "Disconnect";
-"connect" = "Connect";
+"disconnect_button_label" = "Pārtraukt savienojumu";
+"connect_button_label" = "Izveidot savienojumu";

--- a/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/lv.lproj/Localizable.strings
+++ b/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/lv.lproj/Localizable.strings
@@ -1,4 +1,4 @@
-"connected_server_state" = "Savienojums izveidots";
-"disconnected_server_state" = "Savienojums pārtraukts";
 "tray_open_window" = "Atvērt";
 "quit" = "Aizvērt";
+"disconnect" = "Disconnect";
+"connect" = "Connect";

--- a/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/mk.lproj/Localizable.strings
+++ b/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/mk.lproj/Localizable.strings
@@ -1,4 +1,4 @@
-"connected_server_state" = "Поврзано";
-"disconnected_server_state" = "Не е поврзано";
 "tray_open_window" = "Отвори";
 "quit" = "Излези";
+"disconnect" = "Disconnect";
+"connect" = "Connect";

--- a/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/mk.lproj/Localizable.strings
+++ b/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/mk.lproj/Localizable.strings
@@ -1,4 +1,4 @@
 "tray_open_window" = "Отвори";
 "quit" = "Излези";
-"disconnect" = "Disconnect";
-"connect" = "Connect";
+"disconnect_button_label" = "Прекини ја врската";
+"connect_button_label" = "Поврзување";

--- a/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/mn.lproj/Localizable.strings
+++ b/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/mn.lproj/Localizable.strings
@@ -1,4 +1,4 @@
 "tray_open_window" = "Нээх";
 "quit" = "Гарах";
-"disconnect" = "Disconnect";
-"connect" = "Connect";
+"disconnect_button_label" = "Салгах";
+"connect_button_label" = "Холбогдох";

--- a/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/mn.lproj/Localizable.strings
+++ b/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/mn.lproj/Localizable.strings
@@ -1,4 +1,4 @@
-"connected_server_state" = "Холбогдсон";
-"disconnected_server_state" = "Салсан";
 "tray_open_window" = "Нээх";
 "quit" = "Гарах";
+"disconnect" = "Disconnect";
+"connect" = "Connect";

--- a/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/mr.lproj/Localizable.strings
+++ b/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/mr.lproj/Localizable.strings
@@ -1,4 +1,4 @@
-"connected_server_state" = "कनेक्ट केले आहे";
-"disconnected_server_state" = "डिस्कनेक्ट केले";
 "tray_open_window" = "उघडा";
 "quit" = "बाहेर पडा";
+"disconnect" = "Disconnect";
+"connect" = "Connect";

--- a/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/mr.lproj/Localizable.strings
+++ b/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/mr.lproj/Localizable.strings
@@ -1,4 +1,4 @@
 "tray_open_window" = "उघडा";
 "quit" = "बाहेर पडा";
-"disconnect" = "Disconnect";
-"connect" = "Connect";
+"disconnect_button_label" = "डिस्कनेक्ट करा";
+"connect_button_label" = "कनेक्ट करा";

--- a/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/ms.lproj/Localizable.strings
+++ b/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/ms.lproj/Localizable.strings
@@ -1,4 +1,4 @@
 "tray_open_window" = "Buka";
 "quit" = "Keluar";
-"disconnect" = "Disconnect";
-"connect" = "Connect";
+"disconnect_button_label" = "Putuskan sambungan";
+"connect_button_label" = "Sambung";

--- a/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/ms.lproj/Localizable.strings
+++ b/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/ms.lproj/Localizable.strings
@@ -1,4 +1,4 @@
-"connected_server_state" = "Disambungkan";
-"disconnected_server_state" = "Diputuskan sambungan";
 "tray_open_window" = "Buka";
 "quit" = "Keluar";
+"disconnect" = "Disconnect";
+"connect" = "Connect";

--- a/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/my.lproj/Localizable.strings
+++ b/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/my.lproj/Localizable.strings
@@ -1,4 +1,4 @@
-"connected_server_state" = "ချိတ်ဆက်ထားသည်";
-"disconnected_server_state" = "ချိတ်ဆက်မထားပါ";
 "tray_open_window" = "ဖွင့်ရန်";
 "quit" = "ထွက်ရန်";
+"disconnect" = "Disconnect";
+"connect" = "Connect";

--- a/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/my.lproj/Localizable.strings
+++ b/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/my.lproj/Localizable.strings
@@ -1,4 +1,4 @@
 "tray_open_window" = "ဖွင့်ရန်";
 "quit" = "ထွက်ရန်";
-"disconnect" = "Disconnect";
-"connect" = "Connect";
+"disconnect_button_label" = "ချိတ်ဆက်မှု ဖြုတ်ရန်";
+"connect_button_label" = "ချိတ်ဆက်ရန်";

--- a/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/ne.lproj/Localizable.strings
+++ b/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/ne.lproj/Localizable.strings
@@ -1,4 +1,4 @@
 "tray_open_window" = "खोल्नुहोस्";
 "quit" = "बाहिरिनुहोस्";
-"disconnect" = "Disconnect";
-"connect" = "Connect";
+"disconnect_button_label" = "डिस्कनेक्ट गर्नुहोस्";
+"connect_button_label" = "कनेक्ट गर्नुहोस्";

--- a/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/ne.lproj/Localizable.strings
+++ b/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/ne.lproj/Localizable.strings
@@ -1,4 +1,4 @@
-"connected_server_state" = "कनेक्ट गरिएको छ";
-"disconnected_server_state" = "डिस्कनेक्ट गरिएको छ";
 "tray_open_window" = "खोल्नुहोस्";
 "quit" = "बाहिरिनुहोस्";
+"disconnect" = "Disconnect";
+"connect" = "Connect";

--- a/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/nl.lproj/Localizable.strings
+++ b/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/nl.lproj/Localizable.strings
@@ -1,4 +1,4 @@
-"connected_server_state" = "Verbonden";
-"disconnected_server_state" = "Verbinding verbroken";
 "tray_open_window" = "Openen";
 "quit" = "Sluiten";
+"disconnect" = "Disconnect";
+"connect" = "Connect";

--- a/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/nl.lproj/Localizable.strings
+++ b/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/nl.lproj/Localizable.strings
@@ -1,4 +1,4 @@
 "tray_open_window" = "Openen";
 "quit" = "Sluiten";
-"disconnect" = "Disconnect";
-"connect" = "Connect";
+"disconnect_button_label" = "Verbinding verbreken";
+"connect_button_label" = "Verbinding maken";

--- a/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/no.lproj/Localizable.strings
+++ b/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/no.lproj/Localizable.strings
@@ -1,4 +1,4 @@
 "tray_open_window" = "Åpne";
 "quit" = "Avslutt";
-"disconnect" = "Disconnect";
-"connect" = "Connect";
+"disconnect_button_label" = "Koble fra";
+"connect_button_label" = "Koble til";

--- a/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/no.lproj/Localizable.strings
+++ b/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/no.lproj/Localizable.strings
@@ -1,4 +1,4 @@
-"connected_server_state" = "Tilkoblet";
-"disconnected_server_state" = "Koblet fra";
 "tray_open_window" = "Åpne";
 "quit" = "Avslutt";
+"disconnect" = "Disconnect";
+"connect" = "Connect";

--- a/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/pl.lproj/Localizable.strings
+++ b/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/pl.lproj/Localizable.strings
@@ -1,4 +1,4 @@
 "tray_open_window" = "Otwórz";
 "quit" = "Zamknij";
-"disconnect" = "Disconnect";
-"connect" = "Connect";
+"disconnect_button_label" = "Odłącz";
+"connect_button_label" = "Połącz";

--- a/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/pl.lproj/Localizable.strings
+++ b/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/pl.lproj/Localizable.strings
@@ -1,4 +1,4 @@
-"connected_server_state" = "Połączono";
-"disconnected_server_state" = "Odłączono";
 "tray_open_window" = "Otwórz";
 "quit" = "Zamknij";
+"disconnect" = "Disconnect";
+"connect" = "Connect";

--- a/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/pt-BR.lproj/Localizable.strings
+++ b/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/pt-BR.lproj/Localizable.strings
@@ -1,4 +1,4 @@
 "tray_open_window" = "Abrir";
 "quit" = "Sair";
-"disconnect" = "Disconnect";
-"connect" = "Connect";
+"disconnect_button_label" = "Desconectar";
+"connect_button_label" = "Conectar";

--- a/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/pt-BR.lproj/Localizable.strings
+++ b/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/pt-BR.lproj/Localizable.strings
@@ -1,4 +1,4 @@
-"connected_server_state" = "Conectado";
-"disconnected_server_state" = "Desconectado";
 "tray_open_window" = "Abrir";
 "quit" = "Sair";
+"disconnect" = "Disconnect";
+"connect" = "Connect";

--- a/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/pt-PT.lproj/Localizable.strings
+++ b/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/pt-PT.lproj/Localizable.strings
@@ -1,4 +1,4 @@
-"connected_server_state" = "Ligado";
-"disconnected_server_state" = "Desligado";
 "tray_open_window" = "Abrir";
 "quit" = "Sair";
+"disconnect" = "Disconnect";
+"connect" = "Connect";

--- a/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/pt-PT.lproj/Localizable.strings
+++ b/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/pt-PT.lproj/Localizable.strings
@@ -1,4 +1,4 @@
 "tray_open_window" = "Abrir";
 "quit" = "Sair";
-"disconnect" = "Disconnect";
-"connect" = "Connect";
+"disconnect_button_label" = "Desligar";
+"connect_button_label" = "Ligar";

--- a/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/ro.lproj/Localizable.strings
+++ b/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/ro.lproj/Localizable.strings
@@ -1,4 +1,4 @@
-"connected_server_state" = "Conectat";
-"disconnected_server_state" = "Deconectat";
 "tray_open_window" = "Deschideți";
 "quit" = "Ieșiți";
+"disconnect" = "Disconnect";
+"connect" = "Connect";

--- a/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/ro.lproj/Localizable.strings
+++ b/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/ro.lproj/Localizable.strings
@@ -1,4 +1,4 @@
 "tray_open_window" = "Deschideți";
 "quit" = "Ieșiți";
-"disconnect" = "Disconnect";
-"connect" = "Connect";
+"disconnect_button_label" = "Deconectați";
+"connect_button_label" = "Conectați";

--- a/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/ru.lproj/Localizable.strings
+++ b/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/ru.lproj/Localizable.strings
@@ -1,4 +1,4 @@
-"connected_server_state" = "Подключен";
-"disconnected_server_state" = "Отключен";
 "tray_open_window" = "Открыть";
 "quit" = "Выйти";
+"disconnect" = "Disconnect";
+"connect" = "Connect";

--- a/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/ru.lproj/Localizable.strings
+++ b/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/ru.lproj/Localizable.strings
@@ -1,4 +1,4 @@
 "tray_open_window" = "Открыть";
 "quit" = "Выйти";
-"disconnect" = "Disconnect";
-"connect" = "Connect";
+"disconnect_button_label" = "Отключить";
+"connect_button_label" = "Подключить";

--- a/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/si.lproj/Localizable.strings
+++ b/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/si.lproj/Localizable.strings
@@ -1,4 +1,4 @@
 "tray_open_window" = "විවෘතයි";
 "quit" = "ඉවත් වන්න";
-"disconnect" = "Disconnect";
-"connect" = "Connect";
+"disconnect_button_label" = "විසන්‍ධි කරන්න";
+"connect_button_label" = "සම්බන්‍ධ කරන්න";

--- a/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/si.lproj/Localizable.strings
+++ b/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/si.lproj/Localizable.strings
@@ -1,4 +1,4 @@
-"connected_server_state" = "සම්බන්‍ධයි";
-"disconnected_server_state" = "විසන්‍ධි විය";
 "tray_open_window" = "විවෘතයි";
 "quit" = "ඉවත් වන්න";
+"disconnect" = "Disconnect";
+"connect" = "Connect";

--- a/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/sk.lproj/Localizable.strings
+++ b/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/sk.lproj/Localizable.strings
@@ -1,4 +1,4 @@
 "tray_open_window" = "Otvoriť";
 "quit" = "Ukončiť";
-"disconnect" = "Disconnect";
-"connect" = "Connect";
+"disconnect_button_label" = "Odpojiť";
+"connect_button_label" = "Pripojiť";

--- a/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/sk.lproj/Localizable.strings
+++ b/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/sk.lproj/Localizable.strings
@@ -1,4 +1,4 @@
-"connected_server_state" = "Pripojené";
-"disconnected_server_state" = "Odpojené";
 "tray_open_window" = "Otvoriť";
 "quit" = "Ukončiť";
+"disconnect" = "Disconnect";
+"connect" = "Connect";

--- a/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/sl.lproj/Localizable.strings
+++ b/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/sl.lproj/Localizable.strings
@@ -1,4 +1,4 @@
 "tray_open_window" = "Odpri";
 "quit" = "Zapri";
-"disconnect" = "Disconnect";
-"connect" = "Connect";
+"disconnect_button_label" = "Prekini povezavo";
+"connect_button_label" = "Poveži";

--- a/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/sl.lproj/Localizable.strings
+++ b/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/sl.lproj/Localizable.strings
@@ -1,4 +1,4 @@
-"connected_server_state" = "Povezava je vzpostavljena";
-"disconnected_server_state" = "Povezava je prekinjena";
 "tray_open_window" = "Odpri";
 "quit" = "Zapri";
+"disconnect" = "Disconnect";
+"connect" = "Connect";

--- a/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/sq.lproj/Localizable.strings
+++ b/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/sq.lproj/Localizable.strings
@@ -1,4 +1,4 @@
-"connected_server_state" = "Lidhur";
-"disconnected_server_state" = "Shkëputur";
 "tray_open_window" = "Hap";
 "quit" = "Dil";
+"disconnect" = "Disconnect";
+"connect" = "Connect";

--- a/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/sq.lproj/Localizable.strings
+++ b/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/sq.lproj/Localizable.strings
@@ -1,4 +1,4 @@
 "tray_open_window" = "Hap";
 "quit" = "Dil";
-"disconnect" = "Disconnect";
-"connect" = "Connect";
+"disconnect_button_label" = "Shkëput";
+"connect_button_label" = "Lidh";

--- a/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/sr-Latn.lproj/Localizable.strings
+++ b/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/sr-Latn.lproj/Localizable.strings
@@ -1,4 +1,4 @@
-"connected_server_state" = "Povezano je";
-"disconnected_server_state" = "Veza je prekinuta";
 "tray_open_window" = "Otvori";
 "quit" = "Zatvori";
+"disconnect" = "Disconnect";
+"connect" = "Connect";

--- a/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/sr-Latn.lproj/Localizable.strings
+++ b/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/sr-Latn.lproj/Localizable.strings
@@ -1,4 +1,4 @@
 "tray_open_window" = "Otvori";
 "quit" = "Zatvori";
-"disconnect" = "Disconnect";
-"connect" = "Connect";
+"disconnect_button_label" = "Prekini vezu";
+"connect_button_label" = "Poveži se";

--- a/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/sr.lproj/Localizable.strings
+++ b/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/sr.lproj/Localizable.strings
@@ -1,4 +1,4 @@
 "tray_open_window" = "Отвори";
 "quit" = "Затвори";
-"disconnect" = "Disconnect";
-"connect" = "Connect";
+"disconnect_button_label" = "Прекини везу";
+"connect_button_label" = "Повежи се";

--- a/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/sr.lproj/Localizable.strings
+++ b/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/sr.lproj/Localizable.strings
@@ -1,4 +1,4 @@
-"connected_server_state" = "Повезано је";
-"disconnected_server_state" = "Веза је прекинута";
 "tray_open_window" = "Отвори";
 "quit" = "Затвори";
+"disconnect" = "Disconnect";
+"connect" = "Connect";

--- a/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/sv.lproj/Localizable.strings
+++ b/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/sv.lproj/Localizable.strings
@@ -1,4 +1,4 @@
 "tray_open_window" = "Öppna";
 "quit" = "Avsluta";
-"disconnect" = "Disconnect";
-"connect" = "Connect";
+"disconnect_button_label" = "Koppla från";
+"connect_button_label" = "Anslut";

--- a/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/sv.lproj/Localizable.strings
+++ b/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/sv.lproj/Localizable.strings
@@ -1,4 +1,4 @@
-"connected_server_state" = "Ansluten";
-"disconnected_server_state" = "Frånkopplad";
 "tray_open_window" = "Öppna";
 "quit" = "Avsluta";
+"disconnect" = "Disconnect";
+"connect" = "Connect";

--- a/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/sw.lproj/Localizable.strings
+++ b/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/sw.lproj/Localizable.strings
@@ -1,4 +1,4 @@
 "tray_open_window" = "Fungua";
 "quit" = "Funga";
-"disconnect" = "Disconnect";
-"connect" = "Connect";
+"disconnect_button_label" = "Tenganisha";
+"connect_button_label" = "Unganisha";

--- a/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/sw.lproj/Localizable.strings
+++ b/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/sw.lproj/Localizable.strings
@@ -1,4 +1,4 @@
-"connected_server_state" = "Imeunganishwa";
-"disconnected_server_state" = "Imetenganishwa";
 "tray_open_window" = "Fungua";
 "quit" = "Funga";
+"disconnect" = "Disconnect";
+"connect" = "Connect";

--- a/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/ta.lproj/Localizable.strings
+++ b/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/ta.lproj/Localizable.strings
@@ -1,4 +1,4 @@
-"connected_server_state" = "இணைக்கப்பட்டது";
-"disconnected_server_state" = "இணைப்பு துண்டிக்கப்பட்டது";
 "tray_open_window" = "திற";
 "quit" = "வெளியேறு";
+"disconnect" = "Disconnect";
+"connect" = "Connect";

--- a/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/ta.lproj/Localizable.strings
+++ b/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/ta.lproj/Localizable.strings
@@ -1,4 +1,4 @@
 "tray_open_window" = "திற";
 "quit" = "வெளியேறு";
-"disconnect" = "Disconnect";
-"connect" = "Connect";
+"disconnect_button_label" = "இணைப்பைத் துண்டி";
+"connect_button_label" = "இணை";

--- a/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/th.lproj/Localizable.strings
+++ b/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/th.lproj/Localizable.strings
@@ -1,4 +1,4 @@
 "tray_open_window" = "เปิด";
 "quit" = "ปิด";
-"disconnect" = "Disconnect";
-"connect" = "Connect";
+"disconnect_button_label" = "ยกเลิกการเชื่อมต่อ";
+"connect_button_label" = "เชื่อมต่อ";

--- a/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/th.lproj/Localizable.strings
+++ b/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/th.lproj/Localizable.strings
@@ -1,4 +1,4 @@
-"connected_server_state" = "เชื่อมต่อแล้ว";
-"disconnected_server_state" = "ยกเลิกการเชื่อมต่อแล้ว";
 "tray_open_window" = "เปิด";
 "quit" = "ปิด";
+"disconnect" = "Disconnect";
+"connect" = "Connect";

--- a/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/tr.lproj/Localizable.strings
+++ b/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/tr.lproj/Localizable.strings
@@ -1,4 +1,4 @@
-"connected_server_state" = "Bağlanıldı";
-"disconnected_server_state" = "Bağlantı kesildi";
 "tray_open_window" = "Aç";
 "quit" = "Çık";
+"disconnect" = "Disconnect";
+"connect" = "Connect";

--- a/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/tr.lproj/Localizable.strings
+++ b/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/tr.lproj/Localizable.strings
@@ -1,4 +1,4 @@
 "tray_open_window" = "Aç";
 "quit" = "Çık";
-"disconnect" = "Disconnect";
-"connect" = "Connect";
+"disconnect_button_label" = "Bağlantıyı kes";
+"connect_button_label" = "Bağlan";

--- a/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/uk.lproj/Localizable.strings
+++ b/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/uk.lproj/Localizable.strings
@@ -1,4 +1,4 @@
 "tray_open_window" = "Відкрити";
 "quit" = "Вийти";
-"disconnect" = "Disconnect";
-"connect" = "Connect";
+"disconnect_button_label" = "Відключити";
+"connect_button_label" = "Підключити";

--- a/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/uk.lproj/Localizable.strings
+++ b/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/uk.lproj/Localizable.strings
@@ -1,4 +1,4 @@
-"connected_server_state" = "Підключено";
-"disconnected_server_state" = "Відключено";
 "tray_open_window" = "Відкрити";
 "quit" = "Вийти";
+"disconnect" = "Disconnect";
+"connect" = "Connect";

--- a/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/ur.lproj/Localizable.strings
+++ b/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/ur.lproj/Localizable.strings
@@ -1,4 +1,4 @@
-"connected_server_state" = "منسلک ہے";
-"disconnected_server_state" = "غیر منسلک ہے";
 "tray_open_window" = "کھولیں";
 "quit" = "بند کریں";
+"disconnect" = "Disconnect";
+"connect" = "Connect";

--- a/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/ur.lproj/Localizable.strings
+++ b/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/ur.lproj/Localizable.strings
@@ -1,4 +1,4 @@
 "tray_open_window" = "کھولیں";
 "quit" = "بند کریں";
-"disconnect" = "Disconnect";
-"connect" = "Connect";
+"disconnect_button_label" = "غیر منسلک کریں";
+"connect_button_label" = "منسلک کریں";

--- a/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/vi.lproj/Localizable.strings
+++ b/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/vi.lproj/Localizable.strings
@@ -1,4 +1,4 @@
 "tray_open_window" = "Mở";
 "quit" = "Thoát";
-"disconnect" = "Disconnect";
-"connect" = "Connect";
+"disconnect_button_label" = "Ngắt kết nối";
+"connect_button_label" = "Kết nối";

--- a/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/vi.lproj/Localizable.strings
+++ b/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/vi.lproj/Localizable.strings
@@ -1,4 +1,4 @@
-"connected_server_state" = "Đã kết nối";
-"disconnected_server_state" = "Đã ngắt kết nối";
 "tray_open_window" = "Mở";
 "quit" = "Thoát";
+"disconnect" = "Disconnect";
+"connect" = "Connect";

--- a/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/zh-Hans.lproj/Localizable.strings
+++ b/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/zh-Hans.lproj/Localizable.strings
@@ -1,4 +1,4 @@
 "tray_open_window" = "打开";
 "quit" = "退出";
-"disconnect" = "Disconnect";
-"connect" = "Connect";
+"disconnect_button_label" = "断开连接";
+"connect_button_label" = "连接";

--- a/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/zh-Hans.lproj/Localizable.strings
+++ b/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/zh-Hans.lproj/Localizable.strings
@@ -1,4 +1,4 @@
-"connected_server_state" = "已连接";
-"disconnected_server_state" = "已断开连接";
 "tray_open_window" = "打开";
 "quit" = "退出";
+"disconnect" = "Disconnect";
+"connect" = "Connect";

--- a/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/zh-Hant.lproj/Localizable.strings
+++ b/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/zh-Hant.lproj/Localizable.strings
@@ -1,4 +1,4 @@
-"connected_server_state" = "已連線";
-"disconnected_server_state" = "已中斷連線";
 "tray_open_window" = "開啟";
 "quit" = "退出";
+"disconnect" = "Disconnect";
+"connect" = "Connect";

--- a/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/zh-Hant.lproj/Localizable.strings
+++ b/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/zh-Hant.lproj/Localizable.strings
@@ -1,4 +1,4 @@
 "tray_open_window" = "開啟";
 "quit" = "退出";
-"disconnect" = "Disconnect";
-"connect" = "Connect";
+"disconnect_button_label" = "中斷連線";
+"connect_button_label" = "連線";

--- a/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/StatusItemController.swift
+++ b/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/StatusItemController.swift
@@ -46,12 +46,12 @@ class StatusItemController: NSObject {
             comment: "Tray menu entry to quit the application."
         )
         static let connect = NSLocalizedString(
-            "connect",
+            "connect_button_label",
             bundle: Bundle(for: StatusItemController.self),
             comment: "Menu item to connect to VPN."
         )
         static let disconnect = NSLocalizedString(
-            "disconnect",
+            "disconnect_button_label",
             bundle: Bundle(for: StatusItemController.self),
             comment: "Menu item to disconnect from VPN."
         )


### PR DESCRIPTION
- Ran `npm run action client/src/cordova/import_messages ios`
- This failed (well really succeeded with missing strings) since we use a different var name for the connect/disconnect strings.
- Converted `connect` -> `connect_button_label` and `disconnect` -> `disconnect_button_label` to match the variable names in `client/src/www/messages/en.json`
- Reran `npm run action client/src/cordova/import_messages ios`
- Success

Fixes https://github.com/Jigsaw-Code/outline-apps/issues/2612