### PR TITLE
chore: upgrade android ndk to 28

### DIFF
--- a/.github/scripts/android_setup_ci.sh
+++ b/.github/scripts/android_setup_ci.sh
@@ -46,4 +46,4 @@ PATH="${PATH}:${ANDROID_HOME}/platform-tools:${ANDROID_HOME}/cmdline-tools/tools
 # To find the latest version's label:
 #   sdkmanager --list|grep build-tools
 # NDK (side by side) version must be kept in sync with the default build tools NDK version.
-yes | sdkmanager "build-tools;35.0.0" "ndk;26.1.10909125"
+yes | sdkmanager "build-tools;35.0.0" "ndk;28.2.13676358"

--- a/client/src/cordova/android/README.md
+++ b/client/src/cordova/android/README.md
@@ -45,7 +45,7 @@ Alternatively, you can do it on the command-line:
 1. Install platform and build tools:
 
     ```shell
-    sdkmanager "platforms;android-35" "build-tools;35.0.0" "ndk;26.1.10909125" 
+    sdkmanager "platforms;android-35" "build-tools;35.0.0" "ndk;28.2.13676358" 
     ```
 
 1. Install optional components that help development (source code, emulator and image):


### PR DESCRIPTION
Latest stable version: https://developer.android.com/ndk/downloads#stable-downloads

Will support 16kb page sizes: https://developer.android.com/guide/practices/page-sizes#compile-r28

Needs to be tested in the android release pipeline