### PR TITLE
feat: return the connection type in the tunnel config

### DIFF
--- a/client/go/outline/config/types.go
+++ b/client/go/outline/config/types.go
@@ -16,6 +16,7 @@ package config
 
 import (
 	"context"
+	"encoding/json"
 	"net"
 
 	"github.com/Jigsaw-Code/outline-sdk/transport"
@@ -31,6 +32,26 @@ const (
 	ConnTypePartial
 	ConnTypeBlocked
 )
+
+// MarshalJSON implements the json.Marshaler interface.
+func (c ConnType) MarshalJSON() ([]byte, error) {
+	var s string
+	switch c {
+	case ConnTypeDirect:
+		s = "proxyless"
+	case ConnTypeTunneled:
+		s = "proxy"
+	case ConnTypePartial:
+		s = "split"
+	case ConnTypeBlocked:
+		s = "blocked"
+	default:
+		return nil, &json.UnsupportedValueError{
+			Str: "invalid ConnType",
+		}
+	}
+	return json.Marshal(s)
+}
 
 // ConnProviderConfig represents a dialer or endpoint that can create connections.
 type ConnectionProviderInfo struct {

--- a/client/go/outline/config/types.go
+++ b/client/go/outline/config/types.go
@@ -33,7 +33,9 @@ const (
 	ConnTypeBlocked
 )
 
-// MarshalJSON implements the json.Marshaler interface.
+// This is the format used for sending ConnType between go and typescript
+// Keep this in sync with
+// client/web/app/outline_server_repository/config.ts ConnectionType
 func (c ConnType) MarshalJSON() ([]byte, error) {
 	var s string
 	switch c {
@@ -45,11 +47,6 @@ func (c ConnType) MarshalJSON() ([]byte, error) {
 		s = "split"
 	case ConnTypeBlocked:
 		s = "blocked"
-	default:
-		return nil, &json.UnsupportedValueError{
-			Str: "invalid ConnType",
-		}
-	}
 	return json.Marshal(s)
 }
 

--- a/client/go/outline/config/types.go
+++ b/client/go/outline/config/types.go
@@ -36,7 +36,6 @@ const (
 // This is the format used for sending ConnType between go and typescript
 // Keep this in sync with
 // client/web/app/outline_server_repository/config.ts#ConnectionType
-
 func (c ConnType) MarshalJSON() ([]byte, error) {
 	var s string
 	switch c {

--- a/client/go/outline/config/types.go
+++ b/client/go/outline/config/types.go
@@ -35,7 +35,7 @@ const (
 
 // This is the format used for sending ConnType between go and typescript
 // Keep this in sync with
-// client/web/app/outline_server_repository/config.ts ConnectionType
+// client/web/app/outline_server_repository/config.ts#ConnectionType
 func (c ConnType) MarshalJSON() ([]byte, error) {
 	var s string
 	switch c {

--- a/client/go/outline/config/types.go
+++ b/client/go/outline/config/types.go
@@ -27,8 +27,11 @@ import (
 type ConnType int
 
 const (
+	// Proxyless
 	ConnTypeDirect ConnType = iota
+	// Proxy
 	ConnTypeTunneled
+	// Mixed
 	ConnTypePartial
 	ConnTypeBlocked
 )
@@ -40,11 +43,11 @@ func (c ConnType) MarshalJSON() ([]byte, error) {
 	var s string
 	switch c {
 	case ConnTypeDirect:
-		s = "proxyless"
+		s = "direct"
 	case ConnTypeTunneled:
-		s = "proxy"
+		s = "tunneled"
 	case ConnTypePartial:
-		s = "split"
+		s = "partial"
 	case ConnTypeBlocked:
 		s = "blocked"
 	default:

--- a/client/go/outline/config/types.go
+++ b/client/go/outline/config/types.go
@@ -36,6 +36,7 @@ const (
 // This is the format used for sending ConnType between go and typescript
 // Keep this in sync with
 // client/web/app/outline_server_repository/config.ts#ConnectionType
+
 func (c ConnType) MarshalJSON() ([]byte, error) {
 	var s string
 	switch c {
@@ -47,6 +48,11 @@ func (c ConnType) MarshalJSON() ([]byte, error) {
 		s = "split"
 	case ConnTypeBlocked:
 		s = "blocked"
+	default:
+		return nil, &json.UnsupportedValueError{
+			Str: "invalid ConnType",
+		}
+	}
 	return json.Marshal(s)
 }
 

--- a/client/go/outline/parse.go
+++ b/client/go/outline/parse.go
@@ -163,7 +163,6 @@ func doParseTunnelConfig(input string) *InvokeMethodResult {
 
 	streamConnType := result.Client.sd.ConnectionProviderInfo.ConnType
 	packetConnType := result.Client.pl.ConnectionProviderInfo.ConnType
-
 	response.ConnectionType = combinedConnectionType(streamConnType, packetConnType)
 
 	responseBytes, err := json.Marshal(response)

--- a/client/go/outline/parse.go
+++ b/client/go/outline/parse.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/Jigsaw-Code/outline-apps/client/go/outline/config"
 	"github.com/Jigsaw-Code/outline-apps/client/go/outline/platerrors"
 	"github.com/goccy/go-yaml"
 )
@@ -45,8 +46,9 @@ type ProviderTunnelConfig struct {
 
 // firstHopAndTunnelConfigJSON must match FirstHopAndTunnelConfigJson in config.ts.
 type firstHopAndTunnelConfigJSON struct {
-	Client   string `json:"client"`
-	FirstHop string `json:"firstHop"`
+	Client         string       `json:"client"`
+	FirstHop       string       `json:"firstHop"`
+	ConnectionType config.ConnType `json:"connectionType"`
 }
 
 func hasKey[K comparable, V any](m map[K]V, key K) bool {
@@ -140,6 +142,15 @@ func doParseTunnelConfig(input string) *InvokeMethodResult {
 	if streamFirstHop == packetFirstHop {
 		response.FirstHop = streamFirstHop
 	}
+
+	streamConnType := result.Client.sd.ConnectionProviderInfo.ConnType
+	packetConnType := result.Client.pl.ConnectionProviderInfo.ConnType
+	if streamConnType == packetConnType {
+		response.ConnectionType = streamConnType
+	} else {
+		response.ConnectionType = config.ConnTypePartial
+	}
+
 	responseBytes, err := json.Marshal(response)
 	if err != nil {
 		return &InvokeMethodResult{

--- a/client/go/outline/parse.go
+++ b/client/go/outline/parse.go
@@ -57,21 +57,21 @@ func hasKey[K comparable, V any](m map[K]V, key K) bool {
 }
 
 func combinedConnectionType(streamConnType, packetConnType config.ConnType) config.ConnType {
-	// Matching
+	// When one connection is blocked is always the other connection type
+	if streamConnType == config.ConnTypeBlocked {
+		return packetConnType
+	}
+	if packetConnType == config.ConnTypeBlocked {
+		return streamConnType
+	}
+
+	// Matching connection type
 	if streamConnType == packetConnType {
 		return streamConnType
-		// Any split is always fully split
-	} else if streamConnType == config.ConnTypePartial || packetConnType == config.ConnTypePartial {
-		return config.ConnTypePartial
-		// Blocked is always the other connection type
-	} else if streamConnType == config.ConnTypeBlocked {
-		return packetConnType
-	} else if packetConnType == config.ConnTypeBlocked {
-		return streamConnType
-		// Any other non-match is split
-	} else {
-		return config.ConnTypePartial
 	}
+
+	// Connections are non-matching and not blocked
+	return config.ConnTypePartial
 }
 
 func doParseTunnelConfig(input string) *InvokeMethodResult {

--- a/client/go/outline/parse_test.go
+++ b/client/go/outline/parse_test.go
@@ -112,7 +112,7 @@ func Test_doParseTunnel_SSURL(t *testing.T) {
 	result := doParseTunnelConfig(transportConfig)
 	require.Nil(t, result.Error)
 	require.Equal(t,
-		`{"client":"{\"transport\":\"ss://Y2hhY2hhMjAtaWV0Zi1wb2x5MTMwNTpTRUNSRVQ@example.com:4321/\"}","firstHop":"example.com:4321","connectionType":"proxy"}`,
+		`{"client":"{\"transport\":\"ss://Y2hhY2hhMjAtaWV0Zi1wb2x5MTMwNTpTRUNSRVQ@example.com:4321/\"}","firstHop":"example.com:4321","connectionType":"tunneled"}`,
 		result.Value)
 
 	matchTransportConfig(t, transportConfig, result.Value)
@@ -123,7 +123,7 @@ func Test_doParseTunnel_SSURL_With_Comment(t *testing.T) {
 	result := doParseTunnelConfig(transportConfig)
 	require.Nil(t, result.Error)
 	require.Equal(t,
-		`{"client":"{\"transport\":\"ss://Y2hhY2hhMjAtaWV0Zi1wb2x5MTMwNTpTRUNSRVQ@example.com:4321/\"}","firstHop":"example.com:4321","connectionType":"proxy"}`,
+		`{"client":"{\"transport\":\"ss://Y2hhY2hhMjAtaWV0Zi1wb2x5MTMwNTpTRUNSRVQ@example.com:4321/\"}","firstHop":"example.com:4321","connectionType":"tunneled"}`,
 		result.Value)
 
 	matchTransportConfig(t, transportConfig, result.Value)
@@ -140,7 +140,7 @@ func Test_doParseTunnel_LegacyJSON(t *testing.T) {
 	result := doParseTunnelConfig(transportConfig)
 	require.Nil(t, result.Error)
 	require.Equal(t,
-		`{"client":"{\"transport\":{\"method\":\"chacha20-ietf-poly1305\",\"password\":\"SECRET\",\"prefix\":\"SSH-2.0\\r\\n\",\"server\":\"example.com\",\"server_port\":4321}}","firstHop":"example.com:4321","connectionType":"proxy"}`,
+		`{"client":"{\"transport\":{\"method\":\"chacha20-ietf-poly1305\",\"password\":\"SECRET\",\"prefix\":\"SSH-2.0\\r\\n\",\"server\":\"example.com\",\"server_port\":4321}}","firstHop":"example.com:4321","connectionType":"tunneled"}`,
 		result.Value)
 
 	matchTransportConfig(t, transportConfig, result.Value)
@@ -161,7 +161,7 @@ transport:
 
 	require.Nil(t, result.Error)
 	require.Equal(t,
-		`{"client":"{\"transport\":{\"$type\":\"tcpudp\",\"tcp\":{\"$type\":\"shadowsocks\",\"cipher\":\"chacha20-ietf-poly1305\",\"endpoint\":\"example.com:80\",\"secret\":\"SECRET\"},\"udp\":{\"$type\":\"shadowsocks\",\"cipher\":\"chacha20-ietf-poly1305\",\"endpoint\":\"example.com:80\",\"secret\":\"SECRET\"}}}","firstHop":"example.com:80","connectionType":"proxy"}`,
+		`{"client":"{\"transport\":{\"$type\":\"tcpudp\",\"tcp\":{\"$type\":\"shadowsocks\",\"cipher\":\"chacha20-ietf-poly1305\",\"endpoint\":\"example.com:80\",\"secret\":\"SECRET\"},\"udp\":{\"$type\":\"shadowsocks\",\"cipher\":\"chacha20-ietf-poly1305\",\"endpoint\":\"example.com:80\",\"secret\":\"SECRET\"}}}","firstHop":"example.com:80","connectionType":"tunneled"}`,
 		result.Value)
 
 	matchClientConfig(t, clientConfig, result.Value)

--- a/client/go/outline/parse_test.go
+++ b/client/go/outline/parse_test.go
@@ -18,6 +18,7 @@ import (
 	"encoding/json"
 	"testing"
 
+	"github.com/Jigsaw-Code/outline-apps/client/go/outline/config"
 	"github.com/Jigsaw-Code/outline-apps/client/go/outline/platerrors"
 	"github.com/goccy/go-yaml"
 	"github.com/goccy/go-yaml/ast"
@@ -66,12 +67,52 @@ func matchTransportConfig(t *testing.T, transportConfigString string, firstHopAn
 	require.Equal(t, expected, actual["transport"])
 }
 
+func TestCombinedConnectionType(t *testing.T) {
+	testCases := []struct {
+		name           string
+		streamConnType config.ConnType
+		packetConnType config.ConnType
+		expected       config.ConnType
+	}{
+		// Matching types
+		{"Direct-Direct", config.ConnTypeDirect, config.ConnTypeDirect, config.ConnTypeDirect},
+		{"Tunneled-Tunneled", config.ConnTypeTunneled, config.ConnTypeTunneled, config.ConnTypeTunneled},
+		{"Partial-Partial", config.ConnTypePartial, config.ConnTypePartial, config.ConnTypePartial},
+		{"Blocked-Blocked", config.ConnTypeBlocked, config.ConnTypeBlocked, config.ConnTypeBlocked},
+
+		// One is Partial
+		{"Direct-Partial", config.ConnTypeDirect, config.ConnTypePartial, config.ConnTypePartial},
+		{"Partial-Direct", config.ConnTypePartial, config.ConnTypeDirect, config.ConnTypePartial},
+		{"Tunneled-Partial", config.ConnTypeTunneled, config.ConnTypePartial, config.ConnTypePartial},
+		{"Partial-Tunneled", config.ConnTypePartial, config.ConnTypeTunneled, config.ConnTypePartial},
+		{"Blocked-Partial", config.ConnTypeBlocked, config.ConnTypePartial, config.ConnTypePartial},
+		{"Partial-Blocked", config.ConnTypePartial, config.ConnTypeBlocked, config.ConnTypePartial},
+
+		// One is Blocked
+		{"Direct-Blocked", config.ConnTypeDirect, config.ConnTypeBlocked, config.ConnTypeDirect},
+		{"Blocked-Direct", config.ConnTypeBlocked, config.ConnTypeDirect, config.ConnTypeDirect},
+		{"Tunneled-Blocked", config.ConnTypeTunneled, config.ConnTypeBlocked, config.ConnTypeTunneled},
+		{"Blocked-Tunneled", config.ConnTypeBlocked, config.ConnTypeTunneled, config.ConnTypeTunneled},
+
+		// Split between transports
+		{"Direct-Tunneled", config.ConnTypeDirect, config.ConnTypeTunneled, config.ConnTypePartial},
+		{"Tunneled-Direct", config.ConnTypeTunneled, config.ConnTypeDirect, config.ConnTypePartial},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := combinedConnectionType(tc.streamConnType, tc.packetConnType)
+			require.Equal(t, tc.expected, result)
+		})
+	}
+}
+
 func Test_doParseTunnel_SSURL(t *testing.T) {
 	transportConfig := "ss://Y2hhY2hhMjAtaWV0Zi1wb2x5MTMwNTpTRUNSRVQ@example.com:4321/"
 	result := doParseTunnelConfig(transportConfig)
 	require.Nil(t, result.Error)
 	require.Equal(t,
-		`{"client":"{\"transport\":\"ss://Y2hhY2hhMjAtaWV0Zi1wb2x5MTMwNTpTRUNSRVQ@example.com:4321/\"}","firstHop":"example.com:4321"}`,
+		`{"client":"{\"transport\":\"ss://Y2hhY2hhMjAtaWV0Zi1wb2x5MTMwNTpTRUNSRVQ@example.com:4321/\"}","firstHop":"example.com:4321","connectionType":"proxy"}`,
 		result.Value)
 
 	matchTransportConfig(t, transportConfig, result.Value)
@@ -82,7 +123,7 @@ func Test_doParseTunnel_SSURL_With_Comment(t *testing.T) {
 	result := doParseTunnelConfig(transportConfig)
 	require.Nil(t, result.Error)
 	require.Equal(t,
-		`{"client":"{\"transport\":\"ss://Y2hhY2hhMjAtaWV0Zi1wb2x5MTMwNTpTRUNSRVQ@example.com:4321/\"}","firstHop":"example.com:4321"}`,
+		`{"client":"{\"transport\":\"ss://Y2hhY2hhMjAtaWV0Zi1wb2x5MTMwNTpTRUNSRVQ@example.com:4321/\"}","firstHop":"example.com:4321","connectionType":"proxy"}`,
 		result.Value)
 
 	matchTransportConfig(t, transportConfig, result.Value)
@@ -99,7 +140,7 @@ func Test_doParseTunnel_LegacyJSON(t *testing.T) {
 	result := doParseTunnelConfig(transportConfig)
 	require.Nil(t, result.Error)
 	require.Equal(t,
-		`{"client":"{\"transport\":{\"method\":\"chacha20-ietf-poly1305\",\"password\":\"SECRET\",\"prefix\":\"SSH-2.0\\r\\n\",\"server\":\"example.com\",\"server_port\":4321}}","firstHop":"example.com:4321"}`,
+		`{"client":"{\"transport\":{\"method\":\"chacha20-ietf-poly1305\",\"password\":\"SECRET\",\"prefix\":\"SSH-2.0\\r\\n\",\"server\":\"example.com\",\"server_port\":4321}}","firstHop":"example.com:4321","connectionType":"proxy"}`,
 		result.Value)
 
 	matchTransportConfig(t, transportConfig, result.Value)
@@ -120,7 +161,7 @@ transport:
 
 	require.Nil(t, result.Error)
 	require.Equal(t,
-		`{"client":"{\"transport\":{\"$type\":\"tcpudp\",\"tcp\":{\"$type\":\"shadowsocks\",\"cipher\":\"chacha20-ietf-poly1305\",\"endpoint\":\"example.com:80\",\"secret\":\"SECRET\"},\"udp\":{\"$type\":\"shadowsocks\",\"cipher\":\"chacha20-ietf-poly1305\",\"endpoint\":\"example.com:80\",\"secret\":\"SECRET\"}}}","firstHop":"example.com:80"}`,
+		`{"client":"{\"transport\":{\"$type\":\"tcpudp\",\"tcp\":{\"$type\":\"shadowsocks\",\"cipher\":\"chacha20-ietf-poly1305\",\"endpoint\":\"example.com:80\",\"secret\":\"SECRET\"},\"udp\":{\"$type\":\"shadowsocks\",\"cipher\":\"chacha20-ietf-poly1305\",\"endpoint\":\"example.com:80\",\"secret\":\"SECRET\"}}}","firstHop":"example.com:80","connectionType":"proxy"}`,
 		result.Value)
 
 	matchClientConfig(t, clientConfig, result.Value)

--- a/client/web/app/outline_server_repository/config.spec.ts
+++ b/client/web/app/outline_server_repository/config.spec.ts
@@ -40,7 +40,7 @@ describe('parseAccessKey', () => {
         'My Server',
         'first-hop:4321',
         clientConfig,
-        'tunneled'
+        config.ConnectionType.TUNNELED
       )
     );
   });
@@ -64,7 +64,7 @@ describe('parseAccessKey', () => {
         'My Server',
         'first-hop:4321',
         clientConfig,
-        'tunneled'
+        config.ConnectionType.TUNNELED
       )
     );
   });

--- a/client/web/app/outline_server_repository/config.spec.ts
+++ b/client/web/app/outline_server_repository/config.spec.ts
@@ -24,7 +24,9 @@ describe('parseAccessKey', () => {
       if (params.indexOf('invalid') > -1) {
         throw Error('fake invalid config');
       }
-      return `{"client": ${JSON.stringify(params)}, "firstHop": "first-hop:4321"}`;
+      return `{"client": ${JSON.stringify(
+        params
+      )}, "firstHop": "first-hop:4321", "connectionType": "proxy"}`;
     },
   });
 
@@ -37,7 +39,8 @@ describe('parseAccessKey', () => {
       new config.StaticServiceConfig(
         'My Server',
         'first-hop:4321',
-        clientConfig
+        clientConfig,
+        'proxy'
       )
     );
   });
@@ -60,7 +63,8 @@ describe('parseAccessKey', () => {
       new config.StaticServiceConfig(
         'My Server',
         'first-hop:4321',
-        clientConfig
+        clientConfig,
+        'proxy'
       )
     );
   });

--- a/client/web/app/outline_server_repository/config.spec.ts
+++ b/client/web/app/outline_server_repository/config.spec.ts
@@ -26,7 +26,7 @@ describe('parseAccessKey', () => {
       }
       return `{"client": ${JSON.stringify(
         params
-      )}, "firstHop": "first-hop:4321", "connectionType": "proxy"}`;
+      )}, "firstHop": "first-hop:4321", "connectionType": "tunneled"}`;
     },
   });
 
@@ -40,7 +40,7 @@ describe('parseAccessKey', () => {
         'My Server',
         'first-hop:4321',
         clientConfig,
-        'proxy'
+        'tunneled'
       )
     );
   });
@@ -64,7 +64,7 @@ describe('parseAccessKey', () => {
         'My Server',
         'first-hop:4321',
         clientConfig,
-        'proxy'
+        'tunneled'
       )
     );
   });

--- a/client/web/app/outline_server_repository/config.ts
+++ b/client/web/app/outline_server_repository/config.ts
@@ -30,7 +30,8 @@ export class StaticServiceConfig {
   constructor(
     readonly name: string,
     readonly firstHop: string,
-    readonly client: string
+    readonly client: string,
+    readonly connectionType: ConnectionType
   ) {}
 }
 
@@ -56,10 +57,20 @@ export interface TunnelConfigJson {
 }
 
 /**
+ * ConnectionType specifies how the client should connect to the internet.
+ * It's a string enum that mirrors the Go `ConnType` enum.
+ * - `proxy`: The client should connect to the internet through the Outline proxy.
+ * - `proxyless`: The client should connect directly to the internet.
+ * - `split`: The client should connect to the internet through the Outline proxy for some domains, and directly for others.
+ */
+export type ConnectionType = 'proxy' | 'proxyless' | 'split';
+
+/**
  * FirstHopAndTunnelConfigJson holds the first hop information and the tunnel config for convenience.
  */
 export interface FirstHopAndTunnelConfigJson extends TunnelConfigJson {
   firstHop: string;
+  connectionType: ConnectionType;
 }
 
 /**
@@ -92,7 +103,12 @@ export async function parseAccessKey(
     // Static ss:// keys. It encodes the full service config.
     if (noHashAccessKey.protocol === 'ss:') {
       const parsed = await parseTunnelConfig(noHashAccessKey.toString());
-      return new StaticServiceConfig(name, parsed.firstHop, parsed.client);
+      return new StaticServiceConfig(
+        name,
+        parsed.firstHop,
+        parsed.client,
+        parsed.connectionType
+      );
     }
 
     // Dynamic ssconf:// keys. It encodes the location of the service config.

--- a/client/web/app/outline_server_repository/config.ts
+++ b/client/web/app/outline_server_repository/config.ts
@@ -59,7 +59,7 @@ export interface TunnelConfigJson {
 /**
  * ConnectionType specifies how the config connects to the internet
  * keep this type in sync with
- * go/outline/config/types.go ConnType
+ * go/outline/config/types.go#ConnType
  */
 export type ConnectionType = 'proxy' | 'proxyless' | 'split' | 'blocked';
 

--- a/client/web/app/outline_server_repository/config.ts
+++ b/client/web/app/outline_server_repository/config.ts
@@ -61,7 +61,12 @@ export interface TunnelConfigJson {
  * keep this type in sync with
  * go/outline/config/types.go#ConnType
  */
-export type ConnectionType = 'tunneled' | 'direct' | 'partial' | 'blocked';
+export enum ConnectionType {
+  TUNNELED = 'tunneled',
+  DIRECT = 'direct',
+  PARTIAL = 'partial',
+  BLOCKED = 'blocked',
+}
 
 /**
  * FirstHopAndTunnelConfigJson holds the first hop information and the tunnel config for convenience.

--- a/client/web/app/outline_server_repository/config.ts
+++ b/client/web/app/outline_server_repository/config.ts
@@ -57,13 +57,11 @@ export interface TunnelConfigJson {
 }
 
 /**
- * ConnectionType specifies how the client should connect to the internet.
- * It's a string enum that mirrors the Go `ConnType` enum.
- * - `proxy`: The client should connect to the internet through the Outline proxy.
- * - `proxyless`: The client should connect directly to the internet.
- * - `split`: The client should connect to the internet through the Outline proxy for some domains, and directly for others.
+ * ConnectionType specifies how the config connects to the internet
+ * keep this type in sync with
+ * go/outline/config/types.go ConnType
  */
-export type ConnectionType = 'proxy' | 'proxyless' | 'split';
+export type ConnectionType = 'proxy' | 'proxyless' | 'split' | 'blocked';
 
 /**
  * FirstHopAndTunnelConfigJson holds the first hop information and the tunnel config for convenience.

--- a/client/web/app/outline_server_repository/config.ts
+++ b/client/web/app/outline_server_repository/config.ts
@@ -61,7 +61,7 @@ export interface TunnelConfigJson {
  * keep this type in sync with
  * go/outline/config/types.go#ConnType
  */
-export type ConnectionType = 'proxy' | 'proxyless' | 'split' | 'blocked';
+export type ConnectionType = 'tunneled' | 'direct' | 'partial' | 'blocked';
 
 /**
  * FirstHopAndTunnelConfigJson holds the first hop information and the tunnel config for convenience.


### PR DESCRIPTION
Return the ConnectionType back to typescript so we can differentiate various types of connections